### PR TITLE
testsolver/testDiagnostics: set required CPU explicitly

### DIFF
--- a/tests/testsolver.py
+++ b/tests/testsolver.py
@@ -440,6 +440,7 @@ class TestSolver(BaseTest):
 		impl = self.config.iface_cache.get_feed(diag_uri).implementations['diag-5']
 		r = Requirements(top_uri)
 		r.os = 'Windows'
+		r.cpu = 'x86_64'
 		self.assertEqual("There is no possible selection using Diagnostics 5.\n"
 				 "Can't find all required implementations:\n"
 				 "- http://localhost/diagnostics.xml -> (problem)\n"


### PR DESCRIPTION
One of the tests (line 415) assume the host CPU to be x86_64, and does
not explicitly override the CPU field of the Requirements object. This
causes an assertion error on other architectures, as the expected error
message is only displayed if the host CPU is x86_64.

By manually setting r.cpu = 'x86_64', the test works even on other
archs.
