### PR TITLE
Add armv6h->armv6l architecture mapping for Raspberry Pis running Arch Linux ARM

### DIFF
--- a/ocaml/support/system.ml
+++ b/ocaml/support/system.ml
@@ -57,6 +57,7 @@ let canonical_machines = List.fold_left (fun map (k, v) -> StringMap.add k v map
   ("i86pc", "i686");
   ("Power Macintosh", "ppc");
   ("armhf", "armv6l");  (* Not sure what version it should be, but unlikely apt-cache will report an incompatible arch anyway *)
+  ("armv6h", "armv6l"); (* Arch Linux ARM for Raspberry Pi calls it armv6h, assumedly indicating hard-float *)
 ]
 
 (** Return the canonical name for this CPU, or [s] if we don't know one. *)


### PR DESCRIPTION
It seems Arch Linux ARM on the Raspberry Pi reports the architecture as armv6h, where Zero Install works with armv6l for the same hardware. From what I can tell the 'h' indicates hard-float support.

I unfortunately lack the compilation environment to actually deploy this to my pi for testing, but I followed the source, and this does seem like the correct place for this mapping.

As an example what effect this has, I can't install 0repo because of errors such as these:

```
      package:arch:python:3.4.1-1:armv6h (3.4.1-1): Not compatibile with the requested CPU type
```

(Note: the error message actually says "compatibile".)
