### PR TITLE
distro_cache: warn and ignore individual unparseable lines

### DIFF
--- a/ocaml/zeroinstall/distro_cache.ml
+++ b/ocaml/zeroinstall/distro_cache.ml
@@ -69,8 +69,11 @@ class cache (config:General.config) ~(cache_leaf:string) (source:filepath) =
                 if value = "-" then (
                   Hashtbl.replace data.contents key prev    (* Ensure empty list is in the table *)
                 ) else (
-                  let version, machine = U.split_pair U.re_tab value in
-                  Hashtbl.replace data.contents key @@ (Version.parse version, Arch.parse_machine machine) :: prev
+                  try
+                    let version, machine = U.split_pair U.re_tab value in
+                    Hashtbl.replace data.contents key @@ (Version.parse version, Arch.parse_machine machine) :: prev
+                  with ex ->
+                    log_warning ~ex "Failed to parse line '%s' in '%s'" value cache_path
                 )
               done
             with End_of_file -> ()

--- a/tests/rpm/rpm
+++ b/tests/rpm/rpm
@@ -3,5 +3,6 @@ cat << EOF
 ksh	93u-28.2.2	i586
 yast2-update	2.15.23-21	i586
 yast2-mail	2.15.23-2	noarch
+unparseable-version	x.y.z	noarch
 poor=name	2	noarch
 EOF


### PR DESCRIPTION
(rather than rejecting the whole file)

In my two previous fedora upgrades, this distro_cache code has made 0install unusable because a single badly-formatted version number would cause zeroinstall to never find any package-implementations.

The bad version in fedora 21 seems to be fixed, IIRC it was something like 1.2.3.-123 (i.e dash directly following a dot). I don't have any logs to verify this with, unfortunately. It may not be worth fixing that edge case, but clearly bad versions do happen, and it's painful to have one bad version number in an obscure package break the whole system.
