### PR TITLE
Compilation fixes for FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ default: all
 %::
 	[ -d "${BUILDDIR}" ] || mkdir "${BUILDDIR}"
 	[ -d "${DISTDIR}" ] || mkdir "${DISTDIR}"
-	make -C "${BUILDDIR}" -f "${SRCDIR}/Makefile.build" "$@" SRCDIR="${SRCDIR}" BUILDDIR="${BUILDDIR}" DISTDIR="${DISTDIR}" DESTDIR="${DESTDIR}"
+	$(MAKE) -C "${BUILDDIR}" -f "${SRCDIR}/Makefile.build" "$@" SRCDIR="${SRCDIR}" BUILDDIR="${BUILDDIR}" DISTDIR="${DISTDIR}" DESTDIR="${DESTDIR}"
 
 share/locale/zero-install.pot: $(SH)
 	xgettext --sort-by-file --language=Shell -j --output=$@ $(SH)

--- a/Makefile.build
+++ b/Makefile.build
@@ -17,7 +17,7 @@ MACHINE = $(shell uname -m)
 VERSION = $(shell sed -n 's/let version = "\(.*\)"/\1/p' ${SRCDIR}/ocaml/zeroinstall/about.ml)
 
 all:
-	(cd "${SRCDIR}/ocaml" && ocaml build-in.ml "${BUILDDIR}/ocaml")
+	(cd "${SRCDIR}/ocaml" && ocaml build-in.ml "${BUILDDIR}/ocaml" "${MAKE}")
 	(cd "${SRCDIR}" && cp README.md COPYING "${DISTDIR}/")
 	install -d "${DISTDIR}/files"
 	install -d "${DISTDIR}/files/share"

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -25,7 +25,7 @@ test: ocaml
 ocaml: build_dir
 	$(OCAMLBUILD) $(OCAMLBUILDFLAGS) "all-${TYPE}.otarget"
 	#cp 0install.ml "$(OCAML_BUILDDIR)/"
-	if [ "$(OS)" = "Windows_NT" ];then make ocaml_windows; else make ocaml_posix; fi
+	if [ "$(OS)" = "Windows_NT" ];then $(MAKE) ocaml_windows; else $(MAKE) ocaml_posix; fi
 
 # For static Windows version, we also need the runenv.native helper.
 ocaml_windows:

--- a/ocaml/build-in.ml
+++ b/ocaml/build-in.ml
@@ -20,7 +20,7 @@ let make_relative path =
 
 let () =
   match Sys.argv with
-  | [| _prog; ocaml_build_dir |] ->
+  | [| _prog; ocaml_build_dir; make_path |] ->
       let ch = Unix.open_process_in "ocamlbuild -version" in
       let ocamlbuild_version = input_line ch in
       let need_relative_path = Str.string_match (Str.regexp "ocamlbuild 3") ocamlbuild_version 0 in
@@ -36,5 +36,5 @@ let () =
       |> List.filter (fun pair -> not (Str.string_match re_OCAMLLIB pair 0))
       |> Array.of_list in
 
-      Unix.execvpe "make" [| "make"; "OCAML_BUILDDIR=" ^ ocaml_build_dir |] env
+      Unix.execvpe make_path [| make_path; "OCAML_BUILDDIR=" ^ ocaml_build_dir |] env
   | _ -> failwith "usage: ocaml build-in.ml builddir"


### PR DESCRIPTION
This fixes compilation for FreeBSD. FreeBSD does not use GNU Make per default. Fixes #45.