### PR TITLE
ocaml/myocamlbuild.ml: restrict link_gtk to shared linking

### DIFF
--- a/ocaml/myocamlbuild.ml
+++ b/ocaml/myocamlbuild.ml
@@ -165,8 +165,8 @@ let () =
           | Some {version=_; dir} -> dir
           | None -> failwith "lablgtk2 is present, but missing lwt.glib dependency!" in
         (* ("-thread" is needed on Ubuntu 13.04 for some reason, even though it's in the _tags too) *)
-        flag ["library"; "native"; "link_gtk"] (S [A"-thread"; A (gtk_dir / "lablgtk.cmxa"); A (lwt_dir / "lwt-glib.cmxa")]);
-        flag ["library"; "byte"; "link_gtk"] (S [A"-thread"; A (gtk_dir / "lablgtk.cma"); A (lwt_dir / "lwt-glib.cma")]);
+        flag ["library"; "shared"; "native"; "link_gtk"] (S [A"-thread"; A (gtk_dir / "lablgtk.cmxa"); A (lwt_dir / "lwt-glib.cmxa")]);
+        flag ["library"; "shared"; "byte"; "link_gtk"] (S [A"-thread"; A (gtk_dir / "lablgtk.cma"); A (lwt_dir / "lwt-glib.cma")]);
     | None -> () end;
 
     (* We use mypp rather than camlp4of because if you pass -pp and -ppopt to ocamlfind


### PR DESCRIPTION
Before ocamlbuild 0.11, ocamlbuild would build gui_gtk.cmxs from
gui_gtk.cmx directly, and (succesfully) use the "link_gtk" tag at this
step, generating a command-line of the form (details elided):

    ocamlfind ocamlopt -shared -package ...
      lablgtk.cmxa lwt-glib.cmxa
      gui_gtk.cmx
      -o gui_gtk.cmxs

which works just fine.

With ocamlbuild 0.11, the ocamlbuild rules regarding cmx, cmxa and
cmxs have been changed, and the build path is now
`gui_gtk.cmx -> gui_gtk.cmxa -> gui_gtk.cmxs`. On the first step,
producing gui_gtk.cmxa would fail, as link_gtk would also apply
and produce a command-line of the form

    ocamlfind ocamlopt -a -package ...
      lablgtk.cmxa lwt-glib.cmxa
      gui_gtk.cmx
      -o gui_gtk.cmxa

This fails with the following error:

    Option -a cannot be used with .cmxa input files.
    Command exited with code 2.

By restricting the link_gtk tag to only apply when the tag "shared" is
also present, we make sure that the .cmxa libraries are only passed
along during the second step, `gui_gtk.cma -> gui_gtk.cmxs`, where
it works as intended.