### PR TITLE
Remove dependency on extlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The easiest way to get the dependencies is using [OPAM](http://opam.ocamlpro.com
 
     $ opam sw 4.04.0
     $ eval `opam config env`
-    $ opam install yojson xmlm ounit lwt_react extlib ocurl obus lablgtk lwt_glib sha
+    $ opam install yojson xmlm ounit lwt_react ocurl obus lablgtk lwt_glib sha
 
 Note: some of these are optional:
 
@@ -63,14 +63,14 @@ they are new enough). For example, on Debian:
 
     $ sudo apt-get install gettext ocaml-nox ocaml-findlib libyojson-ocaml-dev \
        libxmlm-ocaml-dev camlp4-extra make liblwt-ocaml-dev libounit-ocaml-dev \
-       libextlib-ocaml-dev libcurl-ocaml-dev libsha-ocaml-dev \
+       libcurl-ocaml-dev libsha-ocaml-dev \
        libobus-ocaml-dev liblablgtk2-ocaml-dev liblwt-glib-ocaml-dev
 
 On Fedora:
 
     $ su -c 'yum install gettext ocaml ocaml-findlib ocaml-yojson-devel \
        ocaml-biniou-devel ocaml-easy-format-devel ocaml-xmlm-devel ocaml-camlp4-devel \
-       ocaml-lwt-devel ocaml-ounit-devel ocaml-extlib-devel ocaml-curl-devel \
+       ocaml-lwt-devel ocaml-ounit-devel ocaml-curl-devel \
        ocaml-obus-devel ocaml-lablgtk-devel openssl-devel'
 
 Either way, build and install by running this command in the top-level directory:

--- a/ocaml/.merlin
+++ b/ocaml/.merlin
@@ -9,5 +9,5 @@ S support
 S zeroinstall
 S gui_gtk
 S tests
-PKG yojson xmlm str lwt lwt.unix lwt_react lwt.preemptive extlib curl dynlink lablgtk2 obus oUnit
+PKG yojson xmlm str lwt lwt.unix lwt_react lwt.preemptive curl dynlink lablgtk2 obus oUnit
 EXT lwt

--- a/ocaml/_tags
+++ b/ocaml/_tags
@@ -1,5 +1,5 @@
 false: profile
-true: debug, bin_annot, package(yojson,xmlm,str,lwt,lwt.unix,lwt_react,lwt.preemptive,extlib,curl.lwt,dynlink), thread
+true: debug, bin_annot, package(yojson,xmlm,str,lwt,lwt.unix,lwt_react,lwt.preemptive,curl.lwt,dynlink), thread
 <static_0install.*>: linkall
 <tests/*>: package(oUnit)
 <gui_gtk.*>: package(lablgtk2), link_gtk

--- a/ocaml/support.mlpack
+++ b/ocaml/support.mlpack
@@ -1,4 +1,5 @@
 Argparse
+Base64
 Basedir
 Common
 Gpg

--- a/ocaml/support/base64.ml
+++ b/ocaml/support/base64.ml
@@ -1,0 +1,35 @@
+(* Copyright (C) 2017, Thomas Leonard
+ * See the README file for details, or visit http://0install.net.
+ *)
+
+exception Invalid_char
+
+let decode s i =
+  match s.[i] with
+  | 'A'..'Z' as c -> Char.code c - 65
+  | 'a'..'z' as c -> Char.code c - 97 + 26
+  | '0'..'9' as c -> Char.code c - 48 + 52
+  | '+' -> 62
+  | '/' -> 63
+  | '=' when i = String.length s - 1 -> raise End_of_file
+  | '=' when i = String.length s - 2 && s.[i + 1] = '=' -> raise End_of_file
+  | _ -> raise Invalid_char
+  | exception _ when i = String.length s -> raise End_of_file
+
+(* Every 6 bits of plain text become 8 bits of encoded data, so
+   every 3 bytes (24 bits) of plain text become 4 bytes (32 bits) of output. *)
+let str_decode s =
+  let buf = Buffer.create (3 * ((String.length s + 3) / 4)) in
+  let add c = Buffer.add_char buf (Char.chr c) in
+  let rec aux i =
+    let s1 = decode s i in
+    let s2 = decode s (i + 1) in
+    add @@ (s1 lsl 2) lor (s2 lsr 4);
+    let s3 = decode s (i + 2) in
+    add @@ ((s2 land 0xf) lsl 4) lor (s3 lsr 2);
+    let s4 = decode s (i + 3) in
+    add @@ ((s3 land 0x3) lsl 6) lor s4;
+    aux (i + 4)
+  in
+  try aux 0
+  with End_of_file -> Buffer.contents buf

--- a/ocaml/support/base64.mli
+++ b/ocaml/support/base64.mli
@@ -1,0 +1,9 @@
+(* Copyright (C) 2017, Thomas Leonard
+ * See the README file for details, or visit http://0install.net.
+ *)
+
+(** Base64 decoder. This is only used for GPG signatures - performance is not important. *)
+
+exception Invalid_char
+
+val str_decode : string -> string

--- a/opam
+++ b/opam
@@ -15,7 +15,6 @@ depends: [
   "xmlm"
   "ounit" {test}
   "lwt_react"
-  "extlib"
   "ocurl" {>= "0.7.9"}
   "sha"
   "ocamlbuild" {build}


### PR DESCRIPTION
We were only using the Base64 module (we now bundle a simple decoder).

Note: testing with afl-fuzz, it seems that the new decoder is stricter than extlib about malformed input, but it should process valid input the same.