### PR TITLE
Re-enable safe-string everywhere

### DIFF
--- a/ocaml/_tags
+++ b/ocaml/_tags
@@ -11,5 +11,5 @@ true: warn(A-4-48-58), warn_error(+5+6+10+26)
 "gui_gtk": for-pack(Gui_gtk)
 <utils.c>: link_crypto
 <static_0install.*> or <**/*.native> or <**/*.byte>: linkdep_win(0install.exe.o), linkdep_win(windows.o), package(unix), link(utils.o)
-not <support/gpg.*> and not <zeroinstall/json_connection.*> and not <tests/fake_gpg_agent.*>: safe_string
+true: safe_string
 <_build>: not_hygienic

--- a/ocaml/support/gpg.ml
+++ b/ocaml/support/gpg.ml
@@ -232,7 +232,7 @@ let verify (system:system) xml =
           (open_out_bin tmp)
           (fun ch -> output_string ch sig_data);
 
-        let write_stdin stdin = Lwt_io.write_from_exactly stdin xml 0 index in
+        let write_stdin stdin = Lwt_io.write_from_string_exactly stdin xml 0 index in
         run_gpg_full system ~stdin:write_stdin [
             (* Not all versions support this: *)
             (* '--max-output', str(1024 * 1024), *)

--- a/ocaml/tests/fake_gpg_agent.ml
+++ b/ocaml/tests/fake_gpg_agent.ml
@@ -6,7 +6,7 @@ open Support.Common
 module U = Support.Utils
 
 let write fd msg =
-  Lwt_unix.write fd msg 0 (String.length msg) >>= fun wrote ->
+  Lwt_unix.write_string fd msg 0 (String.length msg) >>= fun wrote ->
   assert (wrote = String.length msg);
   Lwt.return ()
 

--- a/ocaml/zeroinstall/json_connection.ml
+++ b/ocaml/zeroinstall/json_connection.ml
@@ -24,8 +24,8 @@ let read_chunk ch : J.json option Lwt.t =
   | Some size ->
       let size = U.safe_int_of_string size in
       let buf = Bytes.create size in
-      let buf = Bytes.unsafe_to_string buf in   (* Needed for old Lwt API *)
       Lwt_io.read_into_exactly ch buf 0 size >>= fun () ->
+      let buf = Bytes.unsafe_to_string buf in
       log_info "Message from peer: %s" buf;
       Lwt.return (Some (J.from_string buf))
 
@@ -35,8 +35,8 @@ let read_xml_chunk ch =
   | Some size ->
       let size = U.safe_int_of_string size in
       let buf = Bytes.create size in
-      let buf = Bytes.unsafe_to_string buf in
       Lwt_io.read_into_exactly ch buf 0 size >|= fun () ->
+      let buf = Bytes.unsafe_to_string buf in
       Q.parse_input None (Xmlm.make_input (`String (0, buf)))
 
 type opt_xml = [J.json | `WithXML of J.json * Q.element ]


### PR DESCRIPTION
We now depend on a recent Lwt anyway.

This reverts commit 5b32a90ed160c3523a46addd747a9c45a49f56ec.