### PR TITLE
Replace camlp4 build dependency with cppo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 0install
 ========
 
-Copyright Thomas Leonard and others, 2013
+Copyright Thomas Leonard and others, 2017
 
 INTRODUCTION
 ------------
@@ -49,7 +49,7 @@ The easiest way to get the dependencies is using [OPAM](http://opam.ocamlpro.com
 
     $ opam sw 4.04.0
     $ eval `opam config env`
-    $ opam install yojson xmlm ounit lwt_react ocurl obus lablgtk lwt_glib sha
+    $ opam install cppo yojson xmlm ounit lwt_react ocurl obus lablgtk lwt_glib sha
 
 Note: some of these are optional:
 
@@ -61,15 +61,15 @@ Note: some of these are optional:
 Alternatively, you can use your distribution's packages if you prefer (and if
 they are new enough). For example, on Debian:
 
-    $ sudo apt-get install gettext ocaml-nox ocaml-findlib libyojson-ocaml-dev \
-       libxmlm-ocaml-dev camlp4-extra make liblwt-ocaml-dev libounit-ocaml-dev \
+    $ sudo apt-get install cppo gettext ocaml-nox ocaml-findlib libyojson-ocaml-dev \
+       libxmlm-ocaml-dev make liblwt-ocaml-dev libounit-ocaml-dev \
        libcurl-ocaml-dev libsha-ocaml-dev \
        libobus-ocaml-dev liblablgtk2-ocaml-dev liblwt-glib-ocaml-dev
 
 On Fedora:
 
-    $ su -c 'yum install gettext ocaml ocaml-findlib ocaml-yojson-devel \
-       ocaml-biniou-devel ocaml-easy-format-devel ocaml-xmlm-devel ocaml-camlp4-devel \
+    $ su -c 'yum install ocaml-cppo gettext ocaml ocaml-findlib ocaml-yojson-devel \
+       ocaml-biniou-devel ocaml-easy-format-devel ocaml-xmlm-devel \
        ocaml-lwt-devel ocaml-ounit-devel ocaml-curl-devel \
        ocaml-obus-devel ocaml-lablgtk-devel openssl-devel'
 

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -7,7 +7,7 @@ else
 endif
 
 TYPE=native
-OCAMLBUILD=ocamlbuild -j 0 -build-dir "${BUILDDIR_NATIVE}"
+OCAMLBUILD=ocamlbuild -j 0 -use-ocamlfind -plugin-tag 'package(cppo_ocamlbuild)' -build-dir "${BUILDDIR_NATIVE}"
 WINDOWS_LIBS = $(shell dirname $(shell which ocamlc))
 ifeq ($(OS), Windows_NT)
   OCAMLBUILDFLAGS = -lflag -cclib -lflag -lshell32

--- a/ocaml/support/_tags
+++ b/ocaml/support/_tags
@@ -1,3 +1,2 @@
 true: for-pack(Support)
-<windows_api.ml> or <hash.ml>: mypp
 "windows.cma": dllib(-lwindows)

--- a/ocaml/support/hash.cppo.ml
+++ b/ocaml/support/hash.cppo.ml
@@ -17,7 +17,7 @@ class type digest_context =
     method to_bin : string
   end
 
-IFDEF HAVE_SHA THEN
+#ifdef HAVE_SHA
 
 (* Implementation using the "sha" package *)
 
@@ -45,7 +45,7 @@ let create = function
   | "sha256" -> make_context (module Sha256)
   | x -> raise_safe "Unknown digest type '%s'" x
 
-ELSE
+#else
 
 (* Implementation using openssl *)
 
@@ -71,7 +71,7 @@ let create alg =
       Bytes.to_string str_digest
   end
 
-ENDIF
+#endif
 
 let hex_digest ctx = ctx#to_hex
 let update ctx = ctx#update

--- a/ocaml/support/windows_api.cppo.ml
+++ b/ocaml/support/windows_api.cppo.ml
@@ -25,7 +25,7 @@ class type windows_api =
 
 let windowsAPI : windows_api option ref = ref None
 
-IFDEF WINDOWS THEN
+#ifdef WINDOWS
   (* This is only used when compiling native code on Windows, not for the portable bytecode. *)
   external win_get_appdata : unit -> string = "caml_win_get_appdata"
   external win_get_local_appdata : unit -> string = "caml_win_get_local_appdata"
@@ -50,4 +50,4 @@ IFDEF WINDOWS THEN
           None
     end
   )
-ENDIF
+#endif

--- a/ocaml/zeroinstall/_tags
+++ b/ocaml/zeroinstall/_tags
@@ -1,2 +1,1 @@
 true: for-pack(Zeroinstall)
-<dbus.ml>: mypp

--- a/ocaml/zeroinstall/dbus.cppo.ml
+++ b/ocaml/zeroinstall/dbus.cppo.ml
@@ -6,7 +6,7 @@
 
 open Support.Common
 
-IFDEF HAVE_DBUS THEN
+#ifdef HAVE_DBUS
 module OBus_bus = OBus_bus
 module OBus_proxy = OBus_proxy
 module OBus_peer = OBus_peer
@@ -53,7 +53,7 @@ let system () =
       return (`Error "Failed to get D-BUS system bus")
     )
 
-ELSE
+#else
 
 let session ?switch:_ () =
   return (`Error "0install was compiled without D-BUS support")
@@ -217,4 +217,4 @@ module OBus_signal =
     let make _signal = no_dbus
     let emit _info _obj ?peer:_ = no_dbus
   end
-ENDIF
+#endif

--- a/opam
+++ b/opam
@@ -18,7 +18,7 @@ depends: [
   "ocurl" {>= "0.7.9"}
   "sha"
   "ocamlbuild" {build}
-  "camlp4" {build}
+  "cppo_ocamlbuild" {build}
 ]
 depopts: [ "obus" "lablgtk" "lwt_glib" ]
 depexts: [


### PR DESCRIPTION
camlp4 is old, large and incompatible with newer technologies such as ppx and jbuilder.