### PR TITLE
Fix build for Lwt 3.0

### DIFF
--- a/ocaml/_tags
+++ b/ocaml/_tags
@@ -2,7 +2,7 @@ false: profile
 true: debug, bin_annot, package(yojson,xmlm,str,lwt,lwt.unix,lwt_react,lwt.preemptive,curl.lwt,dynlink), thread
 <static_0install.*>: linkall
 <tests/*>: package(oUnit)
-<gui_gtk.*>: package(lablgtk2), link_gtk
+<gui_gtk.*>: package(lablgtk2, lwt_glib), link_gtk
 true: strict_sequence
 true: warn(A-4-48-58), warn_error(+5+6+10+26)
 

--- a/ocaml/gui_gtk/_tags
+++ b/ocaml/gui_gtk/_tags
@@ -1,2 +1,2 @@
 true: for-pack(Gui_gtk)
-true: package(lablgtk2)
+true: package(lablgtk2, lwt_glib)


### PR DESCRIPTION
`lwt.glib` is now `lwt_glib`.