### PR TITLE
Tidy distribution code

### DIFF
--- a/ocaml/gui_gtk/solver_box.ml
+++ b/ocaml/gui_gtk/solver_box.ml
@@ -283,6 +283,7 @@ let run_solver ~show_preferences ~trust_db tools ?test_callback ?(systray=false)
         refresh_loop ()
       | _ -> Lwt.return () in
     let refresh_thread = refresh_loop () in
+    Lwt.on_failure refresh_thread (fun ex -> log_warning ~ex "refresh_thread crashed");
 
     (* Wait for user to click Cancel or Run *)
     user_response >>= fun response ->

--- a/ocaml/options.mli
+++ b/ocaml/options.mli
@@ -70,7 +70,7 @@ type tools = <
   config : Zeroinstall.General.config;
   ui : Zeroinstall.Ui.ui_handler;
   download_pool : Zeroinstall.Downloader.download_pool;
-  distro : Zeroinstall.Distro.distribution;
+  distro : Zeroinstall.Distro.t;
   make_fetcher : Zeroinstall.Progress.watcher -> Zeroinstall.Fetch.fetcher;
   trust_db : Zeroinstall.Trust.trust_db;
   set_use_gui : [`Yes | `No | `Auto] -> unit;

--- a/ocaml/tests/fake_distro.ml
+++ b/ocaml/tests/fake_distro.ml
@@ -19,4 +19,4 @@ let fake_packagekit status =
 
 let make config =
   let packagekit = lazy (fake_packagekit `Ok) in
-  Zeroinstall.Distro_impls.generic_distribution ~packagekit config
+  Zeroinstall.Distro_impls.generic_distribution ~packagekit config |> Zeroinstall.Distro.of_provider

--- a/ocaml/tests/test_distro.ml
+++ b/ocaml/tests/test_distro.ml
@@ -206,7 +206,7 @@ let suite = "distro">::: [
 
     fake_system#set_spawn_handler (Some Fake_system.real_spawn_handler);
 
-    let distro = Distro_impls.generic_distribution ~packagekit config in
+    let distro = Distro_impls.generic_distribution ~packagekit config |> Distro.of_provider in
 
     let open Impl in
     let is_host (id, _impl) = U.starts_with id "package:host:" in
@@ -217,7 +217,7 @@ let suite = "distro">::: [
     let root = Q.parse_input None @@ Xmlm.make_input (`String (0, test_feed)) |> Element.parse_feed in
     let feed = F.parse system root None in
     let () =
-      let impls = distro#get_impls_for_feed ~problem:failwith feed in
+      let impls = Distro.get_impls_for_feed distro ~problem:failwith feed in
       let host_python = find_host impls in
       let python_run =
         try StringMap.find_nf "run" host_python.props.commands
@@ -228,7 +228,7 @@ let suite = "distro">::: [
     let root = Q.parse_input None @@ Xmlm.make_input (`String (0, test_gobject_feed)) |> Element.parse_feed in
     let feed = F.parse system root None in
 
-    let impls = distro#get_impls_for_feed ~problem:failwith feed in
+    let impls = Distro.get_impls_for_feed distro ~problem:failwith feed in
     let host_gobject =
       try impls |> StringMap.bindings |> List.find is_host |> snd
       with Not_found -> skip_if true "No host python-gobject found"; assert false in
@@ -244,7 +244,7 @@ let suite = "distro">::: [
       ~attrs:(Q.AttrMap.singleton "interface" "http://repo.roscidus.com/python/python")
       ~child_nodes:[sel] |> Element.parse_selections in
     match Element.selections sels with
-    | [sel] -> assert (distro#is_installed_quick sel)
+    | [sel] -> assert (Distro.is_installed distro config sel)
     | _ -> assert false
   );
 

--- a/ocaml/tests/test_distro.ml
+++ b/ocaml/tests/test_distro.ml
@@ -324,8 +324,8 @@ let suite = "distro">::: [
     Unix.putenv "PATH" (dpkgdir ^ ":" ^ old_path);
     fake_system#putenv "PATH" (dpkgdir ^ ":" ^ old_path);
     fake_system#set_spawn_handler (Some Fake_system.real_spawn_handler);
-    let deb = Distro_impls.Debian.debian_distribution ~status_file:(dpkgdir +/ "status") ~packagekit config in
-    begin match to_impl_list @@ deb#get_impls_for_feed ~problem:failwith feed with
+    let deb = Distro_impls.Debian.debian_distribution ~status_file:(dpkgdir +/ "status") ~packagekit config |> Distro.of_provider in
+    begin match to_impl_list @@ Distro.get_impls_for_feed deb ~problem:failwith feed with
     | [impl] ->
         Fake_system.assert_str_equal "package:deb:python-bittorrent:3.4.2-10-2:*" (Impl.get_attr_ex "id" impl);
         assert_equal ~msg:"Stability" Stability.Packaged impl.Impl.stability;
@@ -365,7 +365,7 @@ let suite = "distro">::: [
 
     (* Part II *)
     let gimp_feed = get_feed "<package-implementation package='gimp'/>" in
-    deb#get_impls_for_feed ~problem:failwith gimp_feed |> assert_equal StringMap.empty;
+    Distro.get_impls_for_feed deb ~problem:failwith gimp_feed |> assert_equal StringMap.empty;
 
     (* Initially, we only get information about the installed version... *)
     let bt_feed = get_feed "<package-implementation package='python-bittorrent'>\n\
@@ -373,17 +373,16 @@ let suite = "distro">::: [
                                   <version not-before='3'/>\n\
                                 </restricts>\n\
                                 </package-implementation>" in
-    deb#get_impls_for_feed ~problem:failwith bt_feed |> to_impl_list |> List.length |> assert_equal 1;
-
+    Distro.get_impls_for_feed deb ~problem:failwith bt_feed |> to_impl_list |> List.length |> assert_equal 1;
 
     Fake_system.fake_log#reset;
 
     (* Tell distro to fetch information about candidates... *)
-    Lwt_main.run (deb#check_for_candidates ~ui:Fake_system.null_ui bt_feed);
+    Lwt_main.run (Distro.check_for_candidates deb ~ui:Fake_system.null_ui bt_feed);
 
     (* Now we see the uninstalled package *)
     let compare_version a b = compare a.Impl.parsed_version b.Impl.parsed_version in
-    begin match to_impl_list @@ deb#get_impls_for_feed ~problem:failwith bt_feed |> List.sort compare_version with
+    begin match to_impl_list @@ Distro.get_impls_for_feed deb ~problem:failwith bt_feed |> List.sort compare_version with
     | [installed; uninstalled] as impls ->
         (* Check restriction appears for both candidates *)
         impls |> List.iter (fun impl ->
@@ -399,7 +398,7 @@ let suite = "distro">::: [
     end;
 
     let feed = get_feed "<package-implementation package='libxcomposite-dev'/>" in
-    begin match to_impl_list @@ deb#get_impls_for_feed ~problem:failwith feed with
+    begin match to_impl_list @@ Distro.get_impls_for_feed deb ~problem:failwith feed with
     | [libxcomposite] ->
         Fake_system.assert_str_equal "0.3.1-1" @@ Impl.get_attr_ex "version" libxcomposite;
         Fake_system.assert_str_equal "i386" @@ Arch.format_machine_or_star libxcomposite.Impl.machine
@@ -408,14 +407,14 @@ let suite = "distro">::: [
 
     (* Java is special... *)
     let feed = get_feed "<package-implementation package='openjdk-7-jre'/>" in
-    begin match to_impl_list @@ deb#get_impls_for_feed ~problem:failwith feed with
+    begin match to_impl_list @@ Distro.get_impls_for_feed deb ~problem:failwith feed with
     | [impl] -> Fake_system.assert_str_equal "7.3-2.1.1-3" @@ Impl.get_attr_ex "version" impl
     | _ -> assert false end;
 
     (* Check the disk cache works *)
     fake_system#set_spawn_handler None;
-    let deb = Distro_impls.Debian.debian_distribution ~status_file:(dpkgdir +/ "status") ~packagekit config in
-    begin match to_impl_list @@ deb#get_impls_for_feed ~problem:failwith feed with
+    let deb = Distro_impls.Debian.debian_distribution ~status_file:(dpkgdir +/ "status") ~packagekit config |> Distro.of_provider in
+    begin match to_impl_list @@ Distro.get_impls_for_feed deb ~problem:failwith feed with
     | [impl] -> Fake_system.assert_str_equal "7.3-2.1.1-3" @@ Impl.get_attr_ex "version" impl
     | _ -> assert false end;
 

--- a/ocaml/tests/test_distro.ml
+++ b/ocaml/tests/test_distro.ml
@@ -439,7 +439,7 @@ let suite = "distro">::: [
         val id_prefix = "package:test"
 
         method private get_package_impls query =
-          match query.Distro.package_name with
+          match Distro.Query.package query with
           | "foo" ->
               self#add_package_implementation
                 ~main:"foo"

--- a/ocaml/tests/test_driver.ml
+++ b/ocaml/tests/test_driver.ml
@@ -249,7 +249,7 @@ let suite = "driver">::: [
     let distro =
       Distro.of_provider @@ object (_ : Distro.provider)
         method is_valid_package_name _ = true
-        method is_installed_quick = failwith "is_installed"
+        method is_installed = failwith "is_installed"
         method get_impls_for_feed ?init:_ ~problem:_ _feed = StringMap.empty
         method check_for_candidates = raise_safe "Unexpected check_for_candidates"
         method install_distro_packages = raise_safe "install_distro_packages"

--- a/ocaml/tests/test_driver.ml
+++ b/ocaml/tests/test_driver.ml
@@ -250,7 +250,7 @@ let suite = "driver">::: [
       Distro.of_provider @@ object (_ : Distro.provider)
         method is_valid_package_name _ = true
         method is_installed = failwith "is_installed"
-        method get_impls_for_feed ?init:_ ~problem:_ _feed = StringMap.empty
+        method get_impls_for_feed ~problem:_ _feed = StringMap.empty
         method check_for_candidates = raise_safe "Unexpected check_for_candidates"
         method install_distro_packages = raise_safe "install_distro_packages"
         method match_name = (=) "dummy"

--- a/ocaml/tests/test_solver.ml
+++ b/ocaml/tests/test_solver.ml
@@ -107,7 +107,7 @@ let linux_multi_scope_filter = { Scope_filter.
   may_compile = false;
 }
 
-class fake_feed_provider system (distro:Distro.distribution option) =
+class fake_feed_provider system (distro:Distro.provider option) =
   let ifaces = Hashtbl.create 10 in
 
   object (_ : #Feed_provider.feed_provider)

--- a/ocaml/zeroinstall/apps.mli
+++ b/ocaml/zeroinstall/apps.mli
@@ -42,7 +42,7 @@ val get_selections_no_updates : #filesystem -> app -> Selections.t
  * If they're usable but stale, spawn a background update but return immediately. *)
 val get_selections_may_update :
   < config : config; distro :
-    Distro.distribution;
+    Distro.t;
     make_fetcher : Progress.watcher -> Fetch.fetcher;
     ui : Ui.ui_handler; ..> ->
   app -> Selections.t Lwt.t

--- a/ocaml/zeroinstall/compiled.ml
+++ b/ocaml/zeroinstall/compiled.ml
@@ -116,12 +116,11 @@ let of_source ~host_arch impl =
     bindings = [];
     commands = StringMap.empty;
   } bin_element in
-  `Ok {
-    qdom = bin_element;
-    props;
-    stability = impl.stability;
-    os;
-    machine;
-    parsed_version = impl.parsed_version;
-    impl_type = `Binary_of impl
-  }
+  `Ok (Impl.make
+         ~elem:bin_element
+         ~props
+         ~stability:impl.stability
+         ~os ~machine
+         ~version:impl.parsed_version
+         (`Binary_of impl)
+      )

--- a/ocaml/zeroinstall/distro.ml
+++ b/ocaml/zeroinstall/distro.ml
@@ -124,20 +124,17 @@ class virtual distribution config =
           | Exists -> ()
           | UnchangedSince mtime ->
               set FeedAttr.quick_test_mtime (Int64.of_float mtime |> Int64.to_string) end;
-
-      let open Impl in
-      let impl = {
-        qdom = (elem :> [ `Implementation | `Package_impl ] Element.t);
-        os = None;
-        machine;
-        stability = Stability.Packaged;
-        props = {props with attrs = !new_attrs};
-        parsed_version = version;
-        impl_type = `Package_impl { package_state; package_distro = distro_name };
-      } in
-
+      let impl =
+        Impl.make
+          ~elem
+          ~os:None
+          ~machine
+          ~stability:Stability.Packaged
+          ~props:{props with Impl.attrs = !new_attrs}
+          ~version
+          (`Package_impl { Impl.package_state; package_distro = distro_name })
+      in
       if package_state = `Installed then self#fixup_main impl;
-
       query.results := StringMap.add id impl !(query.results)
 
     (** Test whether this <selection> element is still valid. The default implementation tries to load the feed from the

--- a/ocaml/zeroinstall/distro.ml
+++ b/ocaml/zeroinstall/distro.ml
@@ -74,7 +74,6 @@ class type virtual provider =
     method match_name : string -> bool
     method is_installed : Selections.selection -> bool
     method get_impls_for_feed :
-      ?init:(Impl.distro_implementation Support.Common.StringMap.t) ->
       problem:(string -> unit) ->
       Feed.feed ->
       Impl.distro_implementation Support.Common.StringMap.t
@@ -185,8 +184,8 @@ class virtual distribution config =
 
     (** Get the native implementations (installed or candidates for installation) for this feed.
      * This default implementation finds the best <package-implementation> elements and calls [get_package_impls] on each one. *)
-    method get_impls_for_feed ?(init=StringMap.empty) ~problem (feed:Feed.feed) : Impl.distro_implementation StringMap.t =
-      let results = ref init in
+    method get_impls_for_feed ~problem (feed:Feed.feed) : Impl.distro_implementation StringMap.t =
+      let results = ref StringMap.empty in
 
       if check_host_python then (
         Host_python.get host_python feed.Feed.url |> List.iter (fun (id, impl) -> results := StringMap.add id impl !results)
@@ -263,7 +262,7 @@ let install_distro_packages (t:t) ui impls : [ `Ok | `Cancel ] Lwt.t =
         | `Cancel -> Lwt.return `Cancel in
   !groups |> StringMap.bindings |> loop
 
-let get_impls_for_feed t = t#get_impls_for_feed
+let get_impls_for_feed (t:t) ~problem feed = t#get_impls_for_feed ~problem feed
 let check_for_candidates (t:t) ~ui feed = t#check_for_candidates ~ui feed
 
 let is_installed (t:t) config elem =

--- a/ocaml/zeroinstall/distro.ml
+++ b/ocaml/zeroinstall/distro.ml
@@ -227,8 +227,6 @@ class virtual distribution config =
         ) else None
       )
 
-    method virtual check_for_candidates : 'a. ui:(#Packagekit.ui as 'a) -> Feed.feed -> unit Lwt.t
-
     method install_distro_packages : 'a. (#Packagekit.ui as 'a) -> string ->
         (Impl.distro_implementation * Impl.distro_retrieval_method) list -> [ `Ok | `Cancel ] Lwt.t =
       fun ui typ items ->

--- a/ocaml/zeroinstall/distro.mli
+++ b/ocaml/zeroinstall/distro.mli
@@ -23,9 +23,10 @@ class type virtual provider =
     (** Can we use packages for this distribution? For example, MacPortsDistribution can use "MacPorts" and "Darwin" packages. *)
     method match_name : string -> bool
 
-    (** Check whether this <selection> is still valid. If the quick-test-* attributes are present, we use
-        them to check. Otherwise, we call [is_installed]. *)
-    method is_installed_quick : Selections.selection -> bool
+    (** Test whether this <selection> element is still valid. The default implementation tries to load the feed from the
+     * feed cache, calls [distribution#get_impls_for_feed] on it and checks whether the required implementation ID is in the
+     * returned map. Override this if you can provide a more efficient implementation. *)
+    method is_installed : Selections.selection -> bool
 
     (** Get the native implementations (installed or candidates for installation) for this feed.
      * This default implementation finds the best <package-implementation> elements and calls [get_package_impls] on each one.
@@ -79,11 +80,6 @@ class virtual distribution : General.config ->
      * [get_correct_main] to get the correct value. *)
     method private fixup_main : Impl.distro_implementation -> unit
 
-    (** Test whether this <selection> element is still valid. The default implementation tries to load the feed from the
-     * feed cache, calls [distribution#get_impls_for_feed] on it and checks whether the required implementation ID is in the
-     * returned map. Override this if you can provide a more efficient implementation. *)
-    method private is_installed : Selections.selection -> bool
-
     (** Add the implementations for this feed to [query].
      * Called by [get_impls_for_feed] once for each <package-implementation> element. *)
     method virtual private get_package_impls : query -> unit
@@ -135,4 +131,4 @@ val install_distro_packages : t -> #Packagekit.ui -> Impl.distro_implementation 
 
 (** Check whether this <selection> is still valid. If the quick-test-* attributes are present, we use
     them to check. Otherwise, we call [t#is_installed]. *)
-val is_installed : t -> Selections.selection -> bool
+val is_installed : t -> General.config -> Selections.selection -> bool

--- a/ocaml/zeroinstall/distro.mli
+++ b/ocaml/zeroinstall/distro.mli
@@ -17,47 +17,15 @@ type query = {
 type quick_test_condition = Exists | UnchangedSince of float
 type quick_test = (Support.Common.filepath * quick_test_condition)
 
-class virtual distribution : General.config ->
+(** Each distribution provides an object of this type, which provides the distribution-specific glue for 0install. *)
+class type virtual provider =
   object
-    (** Only <package-implementation>s whose names match this regexp will be considered.
-     * The default disallows names starting with '.' or '-' or containing '/', to avoid potential problems with
-     * shell commands and path lookups. *)
-    val valid_package_name : Str.regexp
-
-    (* Should we check for Python and GObject manually? Use [false] if the package manager
-     * can be relied upon to find them. *)
-    val virtual check_host_python : bool
-
-    val virtual distro_name : string
-
-    (** All IDs will start with this string (e.g. "package:deb") *)
-    val virtual id_prefix : string
-
-    (** Paths to search for missing binaries (i.e. the platform default for $PATH) *)
-    val system_paths : string list
-
     (** Can we use packages for this distribution? For example, MacPortsDistribution can use "MacPorts" and "Darwin" packages. *)
     method match_name : string -> bool
-
-    (** Sometimes we don't know the correct path for a binary until the package is installed.
-     * Called by [add_package_implementation] when the package is already installed and may also be
-     * used by [install_distro_packages] when a package becomes installed.
-     * The default implementation checks for a "run" command and calls
-     * [get_correct_main] to get the correct value. *)
-    method private fixup_main : Impl.distro_implementation -> unit
-
-    (** Test whether this <selection> element is still valid. The default implementation tries to load the feed from the
-     * feed cache, calls [distribution#get_impls_for_feed] on it and checks whether the required implementation ID is in the
-     * returned map. Override this if you can provide a more efficient implementation. *)
-    method private is_installed : Selections.selection -> bool
 
     (** Check whether this <selection> is still valid. If the quick-test-* attributes are present, we use
         them to check. Otherwise, we call [is_installed]. *)
     method is_installed_quick : Selections.selection -> bool
-
-    (** Add the implementations for this feed to [query].
-     * Called by [get_impls_for_feed] once for each <package-implementation> element. *)
-    method virtual private get_package_impls : query -> unit
 
     (** Get the native implementations (installed or candidates for installation) for this feed.
      * This default implementation finds the best <package-implementation> elements and calls [get_package_impls] on each one.
@@ -80,6 +48,45 @@ class virtual distribution : General.config ->
 
     (** Check whether this name is possible for this distribution. The default implementation filters using [valid_package_name]. *)
     method is_valid_package_name : string -> bool
+  end
+
+(** A convenient base-class which implementations may like to inherit from. *)
+class virtual distribution : General.config ->
+  object
+    inherit provider
+
+    (** Only <package-implementation>s whose names match this regexp will be considered.
+     * The default disallows names starting with '.' or '-' or containing '/', to avoid potential problems with
+     * shell commands and path lookups. *)
+    val valid_package_name : Str.regexp
+
+    (* Should we check for Python and GObject manually? Use [false] if the package manager
+     * can be relied upon to find them. *)
+    val virtual check_host_python : bool
+
+    val virtual distro_name : string
+
+    (** All IDs will start with this string (e.g. "package:deb") *)
+    val virtual id_prefix : string
+
+    (** Paths to search for missing binaries (i.e. the platform default for $PATH) *)
+    val system_paths : string list
+
+    (** Sometimes we don't know the correct path for a binary until the package is installed.
+     * Called by [add_package_implementation] when the package is already installed and may also be
+     * used by [install_distro_packages] when a package becomes installed.
+     * The default implementation checks for a "run" command and calls
+     * [get_correct_main] to get the correct value. *)
+    method private fixup_main : Impl.distro_implementation -> unit
+
+    (** Test whether this <selection> element is still valid. The default implementation tries to load the feed from the
+     * feed cache, calls [distribution#get_impls_for_feed] on it and checks whether the required implementation ID is in the
+     * returned map. Override this if you can provide a more efficient implementation. *)
+    method private is_installed : Selections.selection -> bool
+
+    (** Add the implementations for this feed to [query].
+     * Called by [get_impls_for_feed] once for each <package-implementation> element. *)
+    method virtual private get_package_impls : query -> unit
 
     (** Called when an installed package is added, or when installation completes, to find the correct main value,
      * since we might not be able to work it out before-hand. The default checks that the path exists and, if not,
@@ -100,9 +107,32 @@ class virtual distribution : General.config ->
       unit
   end
 
-(** Install these packages using the distribution's package manager.
- * Sorts the implementations into groups by their type and then calls [distribution#install_distro_packages] once for each group. *)
-val install_distro_packages : distribution -> #Packagekit.ui -> Impl.distro_implementation list -> [ `Ok | `Cancel ] Lwt.t
-
 (** Return the <package-implementation> elements that best match this distribution. *)
 val get_matching_package_impls : #distribution -> Feed.feed -> ([`Package_impl] Element.t * Impl.properties) list
+
+(** {2 API for users of the distribution abstraction.} *)
+
+type t
+
+(** [of_provider p] is a distribution implemented by [p]. *)
+val of_provider : #provider -> t
+
+(** Get the native implementations (installed or candidates for installation) for this feed.
+    @param init add the results to this map, rather than starting with an empty one
+    @param problem called to add warnings or notes about problems, for diagnostics *)
+val get_impls_for_feed : t -> 
+  ?init:(Impl.distro_implementation Support.Common.StringMap.t) ->
+  problem:(string -> unit) ->
+  Feed.feed ->
+  Impl.distro_implementation Support.Common.StringMap.t
+
+(** Check (asynchronously) for available but currently uninstalled candidates. Once the returned
+    promise resolves, the candidates will be included in future responses from [get_impls_for_feed]. *)
+val check_for_candidates : t -> ui:#Packagekit.ui -> Feed.feed -> unit Lwt.t
+
+(** Install these packages using the distribution's package manager. *)
+val install_distro_packages : t -> #Packagekit.ui -> Impl.distro_implementation list -> [ `Ok | `Cancel ] Lwt.t
+
+(** Check whether this <selection> is still valid. If the quick-test-* attributes are present, we use
+    them to check. Otherwise, we call [t#is_installed]. *)
+val is_installed : t -> Selections.selection -> bool

--- a/ocaml/zeroinstall/distro.mli
+++ b/ocaml/zeroinstall/distro.mli
@@ -37,10 +37,8 @@ class type virtual provider =
 
     (** Get the native implementations (installed or candidates for installation) for this feed.
      * This default implementation finds the best <package-implementation> elements and calls [get_package_impls] on each one.
-     * @param init add the results to this map, rather than starting with an empty one
      * @param problem called to add warnings or notes about problems, for diagnostics *)
     method get_impls_for_feed :
-      ?init:(Impl.distro_implementation Support.Common.StringMap.t) ->
       problem:(string -> unit) ->
       Feed.feed ->
       Impl.distro_implementation Support.Common.StringMap.t
@@ -121,10 +119,8 @@ type t
 val of_provider : #provider -> t
 
 (** Get the native implementations (installed or candidates for installation) for this feed.
-    @param init add the results to this map, rather than starting with an empty one
     @param problem called to add warnings or notes about problems, for diagnostics *)
 val get_impls_for_feed : t -> 
-  ?init:(Impl.distro_implementation Support.Common.StringMap.t) ->
   problem:(string -> unit) ->
   Feed.feed ->
   Impl.distro_implementation Support.Common.StringMap.t

--- a/ocaml/zeroinstall/distro_impls.ml
+++ b/ocaml/zeroinstall/distro_impls.ml
@@ -899,7 +899,8 @@ module Slackware = struct
     end
 end
 
-let get_host_distribution ~packagekit config : Distro.distribution =
+let get_host_distribution ~packagekit config =
+  Distro.of_provider @@
   let exists = config.system#file_exists in
   match Sys.os_type with
   | "Unix" ->

--- a/ocaml/zeroinstall/distro_impls.mli
+++ b/ocaml/zeroinstall/distro_impls.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2013, Thomas Leonard
+(* Copyright (C) 2017, Thomas Leonard
  * See the README file for details, or visit http://0install.net.
  *)
 

--- a/ocaml/zeroinstall/distro_impls.mli
+++ b/ocaml/zeroinstall/distro_impls.mli
@@ -5,7 +5,7 @@
 (** Platform-specific code for interacting with distribution package managers. *)
 
 (** Create a suitable distribution object for this system. *)
-val get_host_distribution : packagekit:(Packagekit.packagekit Lazy.t) -> General.config -> Distro.distribution
+val get_host_distribution : packagekit:(Packagekit.packagekit Lazy.t) -> General.config -> Distro.t
 
 (** {2 The following are exposed only for unit-testing} *)
 

--- a/ocaml/zeroinstall/driver.ml
+++ b/ocaml/zeroinstall/driver.ml
@@ -29,7 +29,7 @@ let get_unavailable_selections config ?distro sels =
     | Selections.PackageSelection ->
         match distro with
         | None -> false
-        | Some (distro:#Distro.distribution) -> not @@ distro#is_installed_quick elem
+        | Some distro -> not @@ Distro.is_installed distro elem
   in
   sels |> Selections.iter (fun role sel ->
     if needs_download sel then (
@@ -156,7 +156,7 @@ let solve_with_downloads config distro fetcher ~(watcher:#Progress.watcher) requ
             | Some (master_feed, _) ->
                 let distro_f = `Distribution_feed f in
                 if not (already_seen distro_f) then (
-                    add_download distro_f (distro#check_for_candidates ~ui:watcher master_feed >|= fun () () ->
+                    add_download distro_f (Distro.check_for_candidates distro ~ui:watcher master_feed >|= fun () () ->
                       feed_provider#forget_distro f
                     )
                 )
@@ -279,7 +279,7 @@ let download_selections config distro fetcher ~include_packages ~(feed_provider:
         match feed_url with
         | `Local_feed _ -> Lwt.return ()
         | `Distribution_feed master_feed_url ->
-            get_latest_feed master_feed_url >>= distro#check_for_candidates ~ui:fetcher#ui
+            get_latest_feed master_feed_url >>= Distro.check_for_candidates distro ~ui:fetcher#ui
         | `Remote_feed _ as feed_url ->
             get_latest_feed feed_url >|= ignore in
 

--- a/ocaml/zeroinstall/driver.ml
+++ b/ocaml/zeroinstall/driver.ml
@@ -29,7 +29,7 @@ let get_unavailable_selections config ?distro sels =
     | Selections.PackageSelection ->
         match distro with
         | None -> false
-        | Some distro -> not @@ Distro.is_installed distro elem
+        | Some distro -> not @@ Distro.is_installed distro config elem
   in
   sels |> Selections.iter (fun role sel ->
     if needs_download sel then (

--- a/ocaml/zeroinstall/driver.mli
+++ b/ocaml/zeroinstall/driver.mli
@@ -10,7 +10,7 @@
 (** Find the best selections for these requirements and return them if available without downloading. 
  * Returns None if we need to refresh feeds or download any implementations. *)
 val quick_solve :
-  < config : General.config; distro : Distro.distribution; .. > ->
+  < config : General.config; distro : Distro.t; .. > ->
   Requirements.t -> Selections.t option
 
 (** Run the solver, then download any feeds that are missing or that need to be
@@ -27,7 +27,7 @@ val quick_solve :
             provider used (which will have cached all the feeds used in the solve).
     *)
 val solve_with_downloads :
-  General.config -> Distro.distribution -> Fetch.fetcher ->
+  General.config -> Distro.t -> Fetch.fetcher ->
   watcher:#Progress.watcher ->
   Requirements.t ->
   force:bool ->
@@ -46,11 +46,11 @@ val download_and_import_feed :
  * @param feed_provider it's more efficient to reuse the provider returned by [solve_with_downloads], if possible
  *)
 val download_selections :
-  General.config -> Distro.distribution ->
+  General.config -> Distro.t ->
   Fetch.fetcher Lazy.t ->
   include_packages:bool ->
   feed_provider:Feed_provider.feed_provider ->
   Selections.t -> [ `Aborted_by_user | `Success ] Lwt.t
 
 (** If [distro] is set then <package-implementation>s are included. Otherwise, they are ignored. *)
-val get_unavailable_selections : General.config -> ?distro:Distro.distribution -> Selections.t -> Selections.selection list
+val get_unavailable_selections : General.config -> ?distro:Distro.t -> Selections.t -> Selections.selection list

--- a/ocaml/zeroinstall/feed.ml
+++ b/ocaml/zeroinstall/feed.ml
@@ -105,15 +105,15 @@ let create_impl system ~local_dir state node =
         let retrieval_methods = Element.retrieval_methods node in
         `Cache_impl { digests = Stores.get_digests node; retrieval_methods; } in
 
-  let impl = {
-    qdom = (node :> [ `Implementation | `Package_impl ] Element.t);
-    props = {!s with requires = List.rev !s.requires};
-    os;
-    machine;
-    stability;
-    parsed_version = Version.parse (get_prop FeedAttr.version);
-    impl_type;
-  } in
+  let impl =
+    Impl.make
+      ~elem:node
+      ~props:{!s with requires = List.rev !s.requires}
+      ~os ~machine
+      ~stability
+      ~version:(Version.parse (get_prop FeedAttr.version))
+      impl_type
+  in
   (id, impl)
 
 let process_group_properties ~local_dir state item =

--- a/ocaml/zeroinstall/feed_provider_impl.ml
+++ b/ocaml/zeroinstall/feed_provider_impl.ml
@@ -10,7 +10,7 @@ module FeedMap = Feed_url.FeedMap
 
 (** Provides feeds to the [Impl_provider.impl_provider] during a solve. Afterwards, it can be used to
     find out which feeds were used (and therefore may need updating). *)
-class feed_provider config (distro:Distro.distribution) =
+class feed_provider config distro =
   object (self : #Feed_provider.feed_provider)
     val mutable cache = FeedMap.empty
     val mutable distro_cache : Feed_provider.distro_impls FeedMap.t = FeedMap.empty
@@ -35,7 +35,7 @@ class feed_provider config (distro:Distro.distribution) =
         let problems = ref [] in
         let problem msg = problems := msg :: !problems in
         let result =
-          let impls = distro#get_impls_for_feed ~problem feed in
+          let impls = Distro.get_impls_for_feed distro ~problem feed in
           let overrides = Feed.load_feed_overrides config url in
           {Feed_provider.impls; overrides; problems = !problems} in
         distro_cache <- FeedMap.add master_feed_url result distro_cache;

--- a/ocaml/zeroinstall/fetch.ml
+++ b/ocaml/zeroinstall/fetch.ml
@@ -100,7 +100,7 @@ let native_path_within_base (system:system) ~tmpdir crossplatform_path =
 exception Aborted
 exception Try_mirror of string  (* An error where we should try the mirror (i.e. a network problem) *)
 
-class fetcher config (trust_db:Trust.trust_db) (distro:Distro.distribution) (download_pool:Downloader.download_pool) (ui:#Progress.watcher) =
+class fetcher config (trust_db:Trust.trust_db) distro (download_pool:Downloader.download_pool) (ui:#Progress.watcher) =
   let downloader = download_pool#with_monitor ui#monitor in
 
   let trust_dialog_lock = Lwt_mutex.create () in      (* Only show one trust dialog at a time *)

--- a/ocaml/zeroinstall/fetch.mli
+++ b/ocaml/zeroinstall/fetch.mli
@@ -24,4 +24,4 @@ class type fetcher =
   end
 
 (** Create a fetcher for this platform. *)
-val make : General.config -> Trust.trust_db -> Distro.distribution -> Downloader.download_pool -> #Progress.watcher -> fetcher
+val make : General.config -> Trust.trust_db -> Distro.t -> Downloader.download_pool -> #Progress.watcher -> fetcher

--- a/ocaml/zeroinstall/gui.mli
+++ b/ocaml/zeroinstall/gui.mli
@@ -68,6 +68,6 @@ val get_bug_report_details : General.config -> role:Solver.role -> (bool * Solve
  * @raise Safe_exception on failure. *)
 val send_bug_report : Sigs.iface_uri -> string -> string Lwt.t
 
-val run_test : General.config -> Distro.distribution -> (Selections.t -> string Lwt.t) -> (bool * Solver.Model.t) -> string Lwt.t
+val run_test : General.config -> Distro.t -> (Selections.t -> string Lwt.t) -> (bool * Solver.Model.t) -> string Lwt.t
 
 val generate_feed_description : General.config -> Trust.trust_db -> Feed.feed -> Feed.feed_overrides -> feed_description Lwt.t

--- a/ocaml/zeroinstall/host_python.ml
+++ b/ocaml/zeroinstall/host_python.ml
@@ -105,18 +105,19 @@ let make_host_impl t path version ~package ?(commands=StringMap.empty) ?(require
     requires;
     bindings = [];
     commands;
-  } in { Impl.
-    qdom = Element.make_impl Q.AttrMap.empty;
-    props;
-    stability = Stability.Packaged;
-    os = None;
-    machine = Some t.host_machine;       (* (hopefully) *)
-    parsed_version = Version.parse version;
-    impl_type = `Package_impl { Impl.
-      package_distro = "host";
-      package_state = `Installed;
-    }
-  }
+  } in
+  Impl.make
+    ~elem:(Element.make_impl Q.AttrMap.empty)
+    ~props
+    ~stability:Stability.Packaged
+    ~os:None
+    ~machine:(Some t.host_machine)       (* (hopefully) *)
+    ~version:(Version.parse version)
+    (`Package_impl { Impl.
+                     package_distro = "host";
+                     package_state = `Installed;
+                   }
+    )
 
 let get t = function
   | `Remote_feed "http://repo.roscidus.com/python/python" as url ->

--- a/ocaml/zeroinstall/impl.ml
+++ b/ocaml/zeroinstall/impl.ml
@@ -82,6 +82,19 @@ and +'a t = {
 type generic_implementation = impl_type t
 type distro_implementation = [ `Package_impl of package_impl ] t
 
+let make ~elem ~props ~stability ~os ~machine ~version impl_type =
+  {
+    qdom = (elem :> [`Implementation | `Package_impl] Element.t);
+    props;
+    stability;
+    os;
+    machine;
+    parsed_version = version;
+    impl_type;
+  }
+
+let with_stability stability t = {t with stability}
+
 let make_command ?source_hint name path : command =
   let elem = Element.make_command ~path ~source_hint name in
   {

--- a/ocaml/zeroinstall/impl.mli
+++ b/ocaml/zeroinstall/impl.mli
@@ -76,6 +76,17 @@ and +'a t = {
 type generic_implementation = impl_type t
 type distro_implementation = [ `Package_impl of package_impl ] t
 
+val make :
+  elem : [< `Implementation | `Package_impl] Element.t ->
+  props : properties ->
+  stability : Stability.t ->
+  os : Arch.os option ->
+  machine : Arch.machine option ->
+  version : Version.t ->
+  'a -> 'a t
+
+val with_stability : Stability.t -> 'a t -> 'a t
+
 (** {2 Utility functions} *)
 
 val make_command :

--- a/ocaml/zeroinstall/impl_provider.ml
+++ b/ocaml/zeroinstall/impl_provider.ml
@@ -85,7 +85,7 @@ class type impl_provider =
 let do_overrides overrides =
   StringMap.map_bindings (fun id impl ->
     match StringMap.find id overrides.Feed.user_stability with
-    | Some stability -> {impl with Impl.stability = stability}
+    | Some stability -> Impl.with_stability stability impl
     | None -> impl
   )
 
@@ -235,7 +235,8 @@ class default_impl_provider config (feed_provider : Feed_provider.feed_provider)
 
   let get_impls ~problem (feed, overrides) =
     let distro_impls = (get_distro_impls ~problem feed :> Impl.existing Impl.t list) in
-    distro_impls @ do_overrides overrides feed.Feed.implementations in
+    let zi_impls = (do_overrides overrides feed.Feed.implementations :> Impl.existing Impl.t list) in
+    distro_impls @ zi_impls in
 
   let cached_digests = Stores.get_available_digests config.system config.stores in
 

--- a/ocaml/zeroinstall/solver.ml
+++ b/ocaml/zeroinstall/solver.ml
@@ -65,20 +65,18 @@ module CoreModel = struct
   let compare_version a b = compare a.Impl.parsed_version b.Impl.parsed_version
 
   let dummy_impl =
-    let open Impl in {
-      qdom = Element.make_impl Qdom.AttrMap.empty;
-      os = None;
-      machine = None;
-      stability = Stability.Testing;
-      props = {
+    Impl.make
+      ~elem:(Element.make_impl Qdom.AttrMap.empty)
+      ~os:None ~machine:None
+      ~stability:Stability.Testing
+      ~props:{ Impl.
         attrs = AttrMap.empty;
         requires = [];
         commands = StringMap.empty;   (* (not used; we can provide any command) *)
         bindings = [];
-      };
-      parsed_version = Version.parse "0";
-      impl_type = `Local_impl "/dummy";
-    }
+      }
+      ~version:(Version.parse "0")
+      (`Local_impl "/dummy")
 
   let dummy_command = { Impl.
     command_qdom = Element.make_command ~source_hint:None "dummy-command";

--- a/ocaml/zeroinstall/ui.mli
+++ b/ocaml/zeroinstall/ui.mli
@@ -17,7 +17,7 @@ class type ui_handler =
      * @param systray is used during background updates - just show an icon in the systray if possible
      *)
     method run_solver :
-      < config : General.config; distro : Distro.distribution; make_fetcher : Progress.watcher -> Fetch.fetcher; .. > ->
+      < config : General.config; distro : Distro.t; make_fetcher : Progress.watcher -> Fetch.fetcher; .. > ->
       ?test_callback:(Selections.t -> string Lwt.t) ->
       ?systray:bool ->
       select_mode ->


### PR DESCRIPTION
- Separate out `Distro.t` from the provider API. This makes it clearer which parts of the API are for users of distributions, and which are things that should be provided by each distribution implementation.

- Split out the interface that *must* be implemented (`Distro.provider`) from the helper base-class (`distribution`).

- Move `Distro.query` to a submodule, make it abstract, and add some helper functions.

- Remove unused `?init` argument on `get_impls_for_feed`.

- Use OCaml 4.02 match exception syntax.

- Fix package filtering on Debian. We intended to pass only available packages to PackageKit, but treated a cached negative result as a valid package.

- Add progress for apt-cache queries, so they are visible and can be cancelled.