### PR TITLE
Detect when SourceForge is in Disaster Recovery mode

### DIFF
--- a/ocaml/zeroinstall/downloader.ml
+++ b/ocaml/zeroinstall/downloader.ml
@@ -40,7 +40,10 @@ let is_redirect connection =
 
 (** Download the contents of [url] into [ch].
  * This runs in a separate (either Lwt or native) thread. *)
-let download_no_follow ~cancelled ?size ?modification_time ?(start_offset=Int64.zero) ~progress connection ch url =
+let download_no_follow ~cancelled ?size ?modification_time ?(start_offset=Int64.zero) ~progress connection ch = function
+  | url when U.starts_with url "https://downloads.sourceforge.net/#!" ->
+    Lwt.return (`Network_failure "SourceForge is currently in Disaster Recovery mode (unusable)")
+  | url ->
   let skip_bytes = ref (Int64.to_int start_offset) in
   let error_buffer = ref "" in
   Lwt.catch (fun () ->

--- a/ocaml/zeroinstall/fetch.ml
+++ b/ocaml/zeroinstall/fetch.ml
@@ -396,6 +396,7 @@ class fetcher config (trust_db:Trust.trust_db) distro (download_pool:Downloader.
           (* There are two mirror systems in use here. First, we try our [mirror_url]. If that fails too,
            * we raise [Try_mirror] to try the other strategy. *)
           let mirror_url = mirror_url |? lazy (raise (Try_mirror primary_msg)) in
+          log_info "Download failed: %s" primary_msg;
           log_warning "Primary download failed; trying mirror URL '%s'..." mirror_url;
           Downloader.download downloader ~switch ?size ~hint:feed mirror_url >>= function
           | `Aborted_by_user -> raise Aborted


### PR DESCRIPTION
When this happens sf.net returns a success code, but the content is just a textual error saying "SourceForge is currently in Disaster Recovery mode".

We now treat this as a network failure and try the mirror instead.

/cc @bastianeicher 