### PR TITLE
Fix Travis tests on macOS

### DIFF
--- a/.travis-extra-deps.sh
+++ b/.travis-extra-deps.sh
@@ -10,6 +10,7 @@ install_on_osx () {
   sudo hdiutil attach XQuartz-2.7.6.dmg
   sudo installer -verbose -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
   brew update &> /dev/null
+  brew unlink python	# Python 3 conflicts with Python 2's /usr/local/bin/2to3-2 file
   brew upgrade gnupg
   brew install gtk+ pygobject
   export PKG_CONFIG_PATH=/usr/local/Library/Homebrew/os/mac/pkgconfig/10.9:/usr/lib/pkgconfig


### PR DESCRIPTION
Error was:

    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /usr/local
    Could not symlink bin/2to3-2
    Target /usr/local/bin/2to3-2
    is a symlink belonging to python. You can unlink it:
      brew unlink python