### PR TITLE
Fix host Python test on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - OPAMVERBOSE=y
     - POST_INSTALL_HOOK="bash .travis-test-compile.sh"
+    - OPAM_VERSION=1.2.2
   matrix:
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.06

--- a/ocaml/tests/fake_system.ml
+++ b/ocaml/tests/fake_system.ml
@@ -536,14 +536,7 @@ let assert_raises_safe_lwt expected_msg fn =
       | ex -> Lwt.fail ex
     )
 
-let temp_dir_name =
-  (* Filename.get_temp_dir_name doesn't exist under 3.12 *)
-  U.realpath real_system
-    begin try Sys.getenv "TEMP" with Not_found ->
-      match Sys.os_type with
-        | "Unix" | "Cygwin" -> "/tmp"
-        | "Win32" -> "."
-        | _ -> failwith "temp_dir_name: unknown filesystem" end
+let temp_dir_name = Filename.get_temp_dir_name ()
 
 let with_tmpdir fn () =
   U.finally_do reset_env ()

--- a/ocaml/zeroinstall/host_python.ml
+++ b/ocaml/zeroinstall/host_python.ml
@@ -34,6 +34,7 @@ let python_test_code =
   "    import gobject\n" ^
   "  if gobject.__file__.startswith('<'):\n" ^
   "    path = gobject.__path__    # Python 3\n" ^
+  "    if not isinstance(path, str): path = path[0]\n" ^
   "    if type(path) is bytes:\n" ^
   "        path = path.decode(sys.getfilesystemencoding())\n" ^
   "  else:\n" ^


### PR DESCRIPTION
On Debian (Python 3.5.3), `__path__` is a string, but on macOS (Python 3.6.5) it's a list.

Error was:

    warning: Failed to get details from Python: Bad JSON: ...