### PR TITLE
Clean up command-building code

### DIFF
--- a/ocaml/zeroinstall/command.mli
+++ b/ocaml/zeroinstall/command.mli
@@ -1,0 +1,17 @@
+(* Copyright (C) 2018, Thomas Leonard
+ * See the README file for details, or visit http://0install.net.
+ *)
+
+(** <command> elements *)
+
+open Support.Common
+
+(** [build_command sels reqs env] is the argv for the command to run to execute [sels] as requested by [reqs].
+    In --dry-run mode, don't complain if the target doesn't exist. *)
+val build_command :
+  ?main:string ->
+  ?dry_run:bool ->
+  (Selections.impl * filepath option) Selections.RoleMap.t ->
+  Selections.requirements ->
+  Env.t ->
+  string list

--- a/ocaml/zeroinstall/exec.ml
+++ b/ocaml/zeroinstall/exec.ml
@@ -96,17 +96,14 @@ let do_exec_binding dry_run builder env impls (role, {Binding.exec_type; Binding
 
 (* Make a map from InterfaceURIs to the selected <selection> and (for non-native packages) paths *)
 let make_selection_map system stores sels =
-  let map = ref Selections.RoleMap.empty in
-  sels |> Selections.iter (fun role sel ->
+  Selections.as_map sels |> Selections.RoleMap.mapi (fun role sel ->
     let path =
       try Selections.get_path system stores sel
       with Stores.Not_stored msg ->
         raise_safe "Missing implementation for '%s' %s: %s" (Selections.Role.to_string role) (Element.version sel) msg
     in
-    let value = (sel, path) in
-    map := Selections.RoleMap.add role value !map
-  );
-  !map
+    (sel, path)
+  )
 
 let get_exec_args config ?main sels args =
   let env = Env.create config.system#environment in

--- a/ocaml/zeroinstall/selections.ml
+++ b/ocaml/zeroinstall/selections.ml
@@ -61,6 +61,8 @@ type dep_info = {
   dep_required_commands : command_name list;
 }
 
+let as_map t = t.index
+
 let re_initial_slash = Str.regexp "^/"
 let re_package = Str.regexp "^package:"
 

--- a/ocaml/zeroinstall/selections.mli
+++ b/ocaml/zeroinstall/selections.mli
@@ -55,6 +55,11 @@ val get_selected_ex : role -> t -> selection
 (** Convert a selections document to XML in the latest format. *)
 val as_xml : t -> Support.Qdom.element
 
+(** Return all bindings *)
+val collect_bindings : t -> (role * Element.binding) list
+
+(** [as_map t] is the map of the selections in [t]. *)
+val as_map : t -> selection RoleMap.t
 
 (** {2 Selection elements} *)
 
@@ -69,6 +74,3 @@ val get_feed : selection -> Sigs.feed_url
 
 (** Get the globally unique ID of this selection (feed + ID) *)
 val get_id : selection -> Feed_url.global_id
-
-(* Return all bindings *)
-val collect_bindings : t -> (role * Element.binding) list


### PR DESCRIPTION
Replace the previous work-around for the OCaml 4.07 with some tidier code that doesn't need it.