### PR TITLE
Move Safe_exception out of Common

### DIFF
--- a/ocaml/add_feed.ml
+++ b/ocaml/add_feed.ml
@@ -7,6 +7,7 @@
 open Options
 open Zeroinstall
 open Zeroinstall.General
+open Support
 open Support.Common
 
 module F = Zeroinstall.Feed
@@ -105,8 +106,8 @@ let handle options flags args =
                 | `No_update ->
                     if missing then raise_safe "Failed to download missing feed"  (* Shouldn't happen *)
                     else print "No update"
-              with Safe_exception (msg, _) when not missing ->
-                log_warning "Update failed: %s" msg
+              with Safe_exn.T e when not missing ->
+                log_warning "Update failed: %a" Safe_exn.pp e
             );
             feed
         | `Local_feed path as feed ->

--- a/ocaml/gui_gtk/app_list_box.ml
+++ b/ocaml/gui_gtk/app_list_box.ml
@@ -6,6 +6,7 @@
 
 open Zeroinstall.General
 open Zeroinstall
+open Support
 open Support.Common
 open Gtk_common
 
@@ -44,7 +45,7 @@ let discover_existing_apps config =
                           match FC.get_cached_feed config url with
                           | Some feed -> feed.F.name
                           | None -> Filename.basename uri
-                        with Safe_exception _ ->
+                        with Safe_exn.T _ ->
                           Filename.basename uri in
                       already_installed := (name, full, uri) :: !already_installed;
                       raise Found

--- a/ocaml/gui_gtk/cache_explorer_box.ml
+++ b/ocaml/gui_gtk/cache_explorer_box.ml
@@ -5,6 +5,7 @@
 (** GTK cache explorer dialog (for "0install store manage") *)
 
 open Zeroinstall.General
+open Support
 open Support.Common
 open Gtk_common
 
@@ -136,10 +137,10 @@ let show_verification_box config ~parent paths =
                incr n_good
             )
             (function 
-              | Safe_exception (msg, _) ->
+              | Safe_exn.T e ->
                 let space = if !n_bad = 0 then "" else "\n\n" in
                 incr n_bad;
-                report_problem @@ Printf.sprintf "%s%s:\n%s\n" space x msg;
+                report_problem @@ Format.asprintf "%s%s:@.%a@." space x Safe_exn.pp e;
                 Lwt.return ()
               | ex -> Lwt.fail ex
             )

--- a/ocaml/gui_gtk/component_box.ml
+++ b/ocaml/gui_gtk/component_box.ml
@@ -4,6 +4,7 @@
 
 (** The per-component dialog (the one with the Feeds and Versions tabs). *)
 
+open Support
 open Support.Common
 open Gtk_common
 open Zeroinstall.General
@@ -182,9 +183,9 @@ let add_remote_feed ~parent ~watcher ~recalculate tools iface () =
                    recalculate ~force:false
             )
             (function
-              | Safe_exception (msg, _) ->
+              | Safe_exn.T e ->
                 box#misc#set_sensitive true;
-                error_label#set_text msg;
+                error_label#set_text (Safe_exn.msg e);
                 error_label#misc#show ();
                 entry#misc#grab_focus ();
                 Lwt.return ()
@@ -217,7 +218,7 @@ let add_local_feed ~parent ~recalculate config iface () =
               Gui.add_feed config iface feed_url;
               box#destroy ();
               recalculate ~force:false
-        with Safe_exception _ as ex -> Alert_box.report_error ~parent:box ex
+        with Safe_exn.T _ as ex -> Alert_box.report_error ~parent:box ex
   );
 
   box#show ()

--- a/ocaml/gui_gtk/gui_progress.ml
+++ b/ocaml/gui_gtk/gui_progress.ml
@@ -4,6 +4,7 @@
 
 (** Keeps track of download progress. *)
 
+open Support
 open Support.Common
 open Gtk_common
 
@@ -65,10 +66,10 @@ let make_watcher solver_box tools ~trust_db reqs =
       )
 
     method report feed_url msg =
-      let msg = Printf.sprintf "Feed '%s': %s" (Zeroinstall.Feed_url.format_url feed_url) msg in
+      let e = Safe_exn.v "Feed '%s': %s" (Zeroinstall.Feed_url.format_url feed_url) msg in
       Gtk_utils.async (fun () ->
         solver_box >|= fun box ->
-        box#report_error (Safe_exception (msg, ref []))
+        box#report_error e
       )
 
     method monitor dl =

--- a/ocaml/gui_gtk/solver_box.ml
+++ b/ocaml/gui_gtk/solver_box.ml
@@ -4,6 +4,7 @@
 
 (** The main GUI window showing the progress of a solve. *)
 
+open Support
 open Support.Common
 open Gtk_common
 
@@ -240,7 +241,7 @@ let run_solver ~show_preferences ~trust_db tools ?test_callback ?(systray=false)
                | `Success -> on_success ()
           )
           (function
-            | Safe_exception _ as ex ->
+            | Safe_exn.T _ as ex ->
               widgets.ok_button#set_active false;
               report_error ex;
               Lwt.return ()

--- a/ocaml/optimise.ml
+++ b/ocaml/optimise.ml
@@ -6,6 +6,7 @@
 
 open Options
 open Zeroinstall.General
+open Support
 open Support.Common
 
 module U = Support.Utils
@@ -130,7 +131,7 @@ let optimise system impl_dir =
     clear ();
     Printf.printf "[%d / %d] Reading manifests...%!" i total;
     try optimise_impl system stats first_copy ~tmpfile impl_dir impl
-    with Safe_exception (msg, _) -> clear (); log_warning "Skipping '%s': %s" impl msg
+    with Safe_exn.T e -> clear (); log_warning "Skipping '%s': %a" impl Safe_exn.pp e
   );
   clear ();
   stats

--- a/ocaml/run.ml
+++ b/ocaml/run.ml
@@ -4,6 +4,7 @@
 
 (** The "0install run" command *)
 
+open Support
 open Support.Common
 open Options
 open Zeroinstall.General
@@ -56,6 +57,6 @@ let handle options flags args =
       match Zeroinstall.Exec.execute_selections ~exec options.config sels run_args ?main:run_opts.main ?wrapper:run_opts.wrapper with
       | `Dry_run msg -> Zeroinstall.Dry_run.log "%s" msg
       | `Ok () -> ()
-    with Safe_exception _ as ex -> reraise_with_context ex "... running %s" arg
+    with Safe_exn.T _ as ex -> reraise_with_context ex "... running %s" arg
   )
   | _ -> raise (Support.Argparse.Usage_error 1)

--- a/ocaml/runenv_shared.ml
+++ b/ocaml/runenv_shared.ml
@@ -4,6 +4,7 @@
 
 (* The main runenv code, used on all systems (POSIX and Windows) *)
 
+open Support
 open Support.Common
 
 (** This is called in a new process by the launcher created by [Zeroinstall.Exec.ensure_runenv]. *)
@@ -17,4 +18,4 @@ let runenv (system:system) args =
       let open Yojson.Basic in
       let envargs = Util.convert_each Util.to_string (from_string s) in
       system#exec (envargs @ args)
-    with Safe_exception _ as ex -> reraise_with_context ex "... launching %s" arg0
+    with Safe_exn.T _ as ex -> reraise_with_context ex "... launching %s" arg0

--- a/ocaml/slave.ml
+++ b/ocaml/slave.ml
@@ -6,6 +6,7 @@
 
 open Options
 open Zeroinstall.General
+open Support
 open Support.Common
 open Zeroinstall
 
@@ -142,7 +143,9 @@ let handle_request config tools ui = function
       Lwt.catch
         (fun () -> select config tools ui requirements refresh)
         (function
-          | Safe_exception (msg, _) -> `List [`String "fail"; `String msg] |> Lwt.return
+          | Safe_exn.T e ->
+            let msg = Format.asprintf "%a" Safe_exn.pp e in
+            `List [`String "fail"; `String msg] |> Lwt.return
           | ex -> Lwt.fail ex
         )
   | _ -> Lwt.return `Bad_request

--- a/ocaml/store.ml
+++ b/ocaml/store.ml
@@ -6,6 +6,7 @@
 
 open Options
 open Zeroinstall.General
+open Support
 open Support.Common
 
 module U = Support.Utils
@@ -103,7 +104,7 @@ let handle_audit options flags args =
       let path = root +/ required_digest_str in
       let digest =
         try Some (Manifest.parse_digest required_digest_str)
-        with Safe_exception _ ->
+        with Safe_exn.T _ ->
           print "Skipping non-implementation directory %s" path;
           None in
 
@@ -118,10 +119,10 @@ let handle_audit options flags args =
             let blank = String.make (String.length msg) ' ' in
             Printf.printf "\r%s\r" blank;
             incr verified;
-          with Safe_exception (msg, _) ->
+          with Safe_exn.T e ->
             print "";
             failures := path :: !failures;
-            print "%s" msg
+            print "%a" Safe_exn.pp e
     )
   );
   if !failures <> [] then  (
@@ -142,7 +143,7 @@ let handle_manifest options flags args =
     | [dir] ->
         let alg =
           try fst (Manifest.parse_digest (Filename.basename dir))
-          with Safe_exception _ -> "sha1new" in
+          with Safe_exn.T _ -> "sha1new" in
         (dir, alg)
     | [dir; alg] ->
         (dir, alg)

--- a/ocaml/support.mlpack
+++ b/ocaml/support.mlpack
@@ -7,6 +7,7 @@ Hash
 Locale
 Logging
 Qdom
+Safe_exn
 Sat
 System
 Urlparse

--- a/ocaml/support/argparse.ml
+++ b/ocaml/support/argparse.ml
@@ -197,14 +197,14 @@ let parse_options valid_options raw_options =
         | None -> raise_safe "Option '%s' is not valid here" name
         | Some reader ->
             try (name, reader#parse values)
-            with Safe_exception _ as ex -> reraise_with_context ex "... processing option '%s'" name in
+            with Safe_exn.T _ as ex -> reraise_with_context ex "... processing option '%s'" name in
 
   List.map parse_option raw_options
 
 let iter_options options fn =
   let process (actual_opt, value) =
     try fn value
-    with Safe_exception _ as ex -> reraise_with_context ex "... processing option '%s'" actual_opt
+    with Safe_exn.T _ as ex -> reraise_with_context ex "... processing option '%s'" actual_opt
   in List.iter process options
 
 (** {2 Handy wrappers for option handlers} *)

--- a/ocaml/support/argparse.mli
+++ b/ocaml/support/argparse.mli
@@ -59,7 +59,7 @@ type 'a parsed_options
 
 val parse_options : ('a, 'b) opt_spec list -> raw_option list -> 'a parsed_options
 
-(** Invoke the callback on each option. If it raises [Safe_exception], add the name of the option to the error message. *)
+(** Invoke the callback on each option. If it raises [Safe_exn.T], add the name of the option to the error message. *)
 val iter_options : 'a parsed_options -> ('a -> unit) -> unit
 
 (** {2 Handy wrappers for option handlers} *)

--- a/ocaml/support/qdom.ml
+++ b/ocaml/support/qdom.ml
@@ -148,7 +148,7 @@ let parse_file (system:#filesystem) ?name path =
     parse_input (Some (name |> default path)) (Xmlm.make_input (`Channel ch))
   )
   with
-  | Safe_exception _ as ex -> reraise_with_context ex "... parsing XML document %s" path
+  | Safe_exn.T _ as ex -> reraise_with_context ex "... parsing XML document %s" path
   | Sys_error msg -> raise_safe "Error parsing XML document '%s': %s" path msg
 
 (** Helper functions. *)

--- a/ocaml/support/qdom.mli
+++ b/ocaml/support/qdom.mli
@@ -56,12 +56,12 @@ type element = {
 
 (** {2 Parsing} *)
 
-(** @raise Safe_exception if the XML is not well formed. *)
+(** @raise Safe_exn.T if the XML is not well formed. *)
 val parse_input : string option -> Xmlm.input -> element
 
 (** Load XML from a file.
  * @param name: optional name to report in location messages (if missing, uses file name)
- * @raise Safe_exception if the XML is not well formed. *)
+ * @raise Safe_exn.T if the XML is not well formed. *)
 val parse_file : #Common.filesystem -> ?name:string -> string -> element
 
 (** {2 Helper functions} *)
@@ -72,14 +72,14 @@ val find : (element -> bool) -> element -> element option
 (** Format a string identifying this element for use in error messages. Includes the source location, if known. *)
 val pp_with_loc : Format.formatter -> element -> unit
 
-(** [raise_elem "Problem with" elem] raises a [Safe_exception] with the message "Problem with <element> at ..." *)
+(** [raise_elem "Problem with" elem] raises a [Safe_exn.T] with the message "Problem with <element> at ..." *)
 val raise_elem : ('a, unit, string, element -> 'b) format4 -> 'a
 
 (** Like [raise_elem], but writing a log record rather than raising an exception. *)
 val log_elem : Logging.level -> ('a, unit, string, element -> unit) format4 -> 'a
 
 (** Returns the text content of this element.
-    @raise Safe_exception if it contains any child nodes. *)
+    @raise Safe_exn.T if it contains any child nodes. *)
 val simple_content : element -> string
 
 (** Write out a (sub)tree.
@@ -123,10 +123,10 @@ module type NS_QUERY = sig
   (** Get the local name of this element, if it's in our namespace. *)
   val tag : element -> string option
 
-  (** @raise Safe_exception if element does not have the expected name and namespace. *)
+  (** @raise Safe_exn.T if element does not have the expected name and namespace. *)
   val check_tag : string -> element -> unit
 
-  (** @raise Safe_exception if element does not have the expected namespace. *)
+  (** @raise Safe_exn.T if element does not have the expected namespace. *)
   val check_ns : element -> unit
 
   (** Create a new element in our namespace.

--- a/ocaml/support/safe_exn.ml
+++ b/ocaml/support/safe_exn.ml
@@ -1,0 +1,47 @@
+(* Copyright (C) 2018, Thomas Leonard
+ * See the README file for details, or visit http://0install.net.
+ *)
+
+type payload = (string * string list ref)
+
+exception T of payload
+
+let msg = fst
+
+let v ?(ctx=[]) f =
+  f |> Format.kasprintf @@ fun msg ->
+  T (msg, ref ctx)
+
+let failf ?(ctx=[]) fmt =
+  fmt |> Format.kasprintf @@ fun msg ->
+  raise (T (msg, ref ctx))
+
+let reraise_with_context ex fmt =
+  fmt |> Format.kasprintf @@ fun context ->
+  begin match ex with
+    | T (_, old_contexts) -> old_contexts := context :: !old_contexts
+    | _ -> Printf.eprintf "warning: Attempt to add note '%s' to non-Safe_exn.T!" context
+  end;
+  raise ex
+
+let with_info note f =
+  Lwt.catch f
+    (function
+      | T (_, old_contexts) as ex ->
+        note @@ Format.kasprintf (fun x -> old_contexts := x :: !old_contexts);
+        raise ex
+      | ex -> Lwt.fail ex
+    )
+
+let pp_ctx_line f line =
+  Format.fprintf f "@,%s" line
+
+let pp f (msg, context) =
+  Format.fprintf f "@[<v>%s%a@]" msg
+    (Format.pp_print_list ~pp_sep:(fun _ _ -> ()) pp_ctx_line) (List.rev !context)
+
+let to_string = function
+  | T e -> Some (Format.asprintf "%a" pp e)
+  | _ -> None
+
+let () = Printexc.register_printer to_string

--- a/ocaml/support/safe_exn.mli
+++ b/ocaml/support/safe_exn.mli
@@ -1,0 +1,31 @@
+(* Copyright (C) 2018, Thomas Leonard
+ * See the README file for details, or visit http://0install.net.
+ *)
+
+(** A [Safe_exn.T] represents an error that is not a bug in 0install.
+    It should be reported to the user without a stack trace by default. *)
+
+type payload
+
+exception T of payload
+(** A [T _] is an exception with a main error message and a list of additional context lines. *)
+
+val v : ?ctx:string list -> ('a, Format.formatter, unit, exn) format4 -> 'a
+(** [v fmt ...] is a new [T] with [fmt ...] as its message. *)
+
+val failf : ?ctx:string list -> ('a, Format.formatter, unit, _) format4 -> 'a
+(** [failf fmt ...] raises a safe exception with the given message (and optional context). *)
+
+val reraise_with_context : exn -> ('a, Format.formatter, unit, _) format4 -> 'a
+(** [reraise_with_context exn fmt ...] adds [fmt ...] to the context of [exn] (which must be
+    a [T]) and re-raises it, preserving the existing stack-trace. *)
+
+val with_info : ((('a, Format.formatter, unit, unit) format4 -> 'a) -> unit) -> (unit -> 'r Lwt.t) -> 'r Lwt.t
+(** [with_info note f] is [f ()], except that if it raises [T _] then
+    we call [note writer] and add whatever is passed to writer to the context. *)
+
+val pp : Format.formatter -> payload -> unit
+(** [pp] formats a payload by writing out the message followed by each context line. *)
+
+val msg : payload -> string
+(** [msg p] is the message part of the payload (without the context) .*)

--- a/ocaml/support/system.ml
+++ b/ocaml/support/system.ml
@@ -90,7 +90,7 @@ module RealSystem (U : UnixType) =
               | None -> Unix.create_process (List.hd args) (Array.of_list args) new_stdin new_stdout new_stderr
               | Some env -> Unix.create_process_env (List.hd args) (Array.of_list args) env new_stdin new_stdout new_stderr
             )
-          with Safe_exception _ as ex ->
+          with Safe_exn.T _ as ex ->
             reraise_with_context ex "... trying to create sub-process '%s'"
               (Logging.format_argv_for_logging args)
 
@@ -141,7 +141,7 @@ module RealSystem (U : UnixType) =
 
         (** A safer, more friendly version of the [Unix.exec*] calls.
             Flushes [stdout] and [stderr]. Ensures [argv[0]] is set to the program called.
-            Reports errors as [Safe_exception]s.
+            Reports errors as [Safe_exn.T]s.
             On Windows, we can't exec, so we spawn a subprocess, wait for it to finish, then
             exit with its exit status.
           *)
@@ -173,7 +173,7 @@ module RealSystem (U : UnixType) =
                 | Some env -> Unix.execve prog_path argv_array env
               )
             )
-          with Safe_exception _ as ex ->
+          with Safe_exn.T _ as ex ->
             let cmd = String.concat " " argv in
             reraise_with_context ex "... trying to exec: %s" cmd
 
@@ -208,7 +208,7 @@ module RealSystem (U : UnixType) =
                 double_fork_detach do_spawn
               )
             )
-          with Safe_exception _ as ex ->
+          with Safe_exn.T _ as ex ->
             let cmd = String.concat " " argv in
             reraise_with_context ex "... trying to spawn: %s" cmd
 
@@ -226,7 +226,7 @@ module RealSystem (U : UnixType) =
               Unix.rename tmpname path
             );
             result
-          with Safe_exception _ as ex -> reraise_with_context ex "... trying to write '%s'" path
+          with Safe_exn.T _ as ex -> reraise_with_context ex "... trying to write '%s'" path
 
         method hardlink = Unix.link
 
@@ -239,7 +239,7 @@ module RealSystem (U : UnixType) =
         method waitpid_non_intr = waitpid_non_intr
 
         (** Call [waitpid] to collect the child.
-            @raise Safe_exception if it didn't exit with a status of 0 (success). *)
+            @raise Safe_exn.T if it didn't exit with a status of 0 (success). *)
         method reap_child ?(kill_first) child_pid =
           let () = match kill_first with
             | None -> ()

--- a/ocaml/support/utils.mli
+++ b/ocaml/support/utils.mli
@@ -6,9 +6,9 @@
 val finally_do : ('a -> unit) -> 'a -> ('a -> 'b) -> 'b
 
 (** [handle_exceptions main args] runs [main args]. If it throws an exception it reports it in a
-    user-friendly way. A [Safe_exception] is displayed with its context.
+    user-friendly way. A [Safe_exn.T] is displayed with its context.
     If stack-traces are enabled, one will be displayed. If not then, if the exception isn't
-    a [Safe_exception], the user is told how to enable them.
+    a [Safe_exn.T], the user is told how to enable them.
     On error, it calls [exit 1]. On success, it returns.
  *)
 val handle_exceptions : ('a -> 'b) -> 'a -> 'b

--- a/ocaml/tests/test.ml
+++ b/ocaml/tests/test.ml
@@ -7,6 +7,7 @@ Unix.putenv "TZ" "Europe/London"
 open OUnit
 open Zeroinstall
 open Zeroinstall.General
+open Support
 open Support.Common
 open Fake_system
 
@@ -132,8 +133,9 @@ let test_option_parsing () =
   begin try
     Support.Argparse.iter_options flags (fun _ -> raise_safe "Error!");
     assert false
-  with Safe_exception ("Error!", ctx) ->
-    assert_str_equal "... processing option '-w'" (List.hd !ctx) end;
+  with Safe_exn.T e ->
+    let msg = Format.asprintf "%a" Safe_exn.pp e in
+    assert_str_equal "Error!\n... processing option '-w'" msg end;
 
   Buffer.reset stdout;
   begin
@@ -276,7 +278,7 @@ let suite =
      assert_str_equal uri (Generic_select.canonical_iface_uri system arg) in
    let check_err arg =
      try (ignore @@ Generic_select.canonical_iface_uri system arg); assert false
-     with Safe_exception _ -> () in
+     with Safe_exn.T _ -> () in
    check "http://example.com/foo.xml" "http://example.com/foo.xml";
    check "alias:./tests/v1-alias" "http://example.com/alias1.xml";
    check "alias:./tests/v2-alias" "http://example.com/alias2.xml";

--- a/ocaml/tests/test_0install.ml
+++ b/ocaml/tests/test_0install.ml
@@ -6,6 +6,7 @@
 
 open Zeroinstall.General
 open Zeroinstall
+open Support
 open Support.Common
 open OUnit
 module Impl = Zeroinstall.Impl
@@ -155,7 +156,8 @@ let suite = "0install">::: [
     fake_system#set_argv [| test_0install; "-cor"; "download"; "http://example.com:8000/Hello.xml"; "--version"; "2" |];
     let () =
       try Fake_system.check_no_output (fun stdout -> Main.main ~stdout system); assert false
-      with Safe_exception (msg, _) ->
+      with Safe_exn.T e ->
+        let msg = Safe_exn.msg e in
         assert_str_equal (
           "Can't find all required implementations:\n" ^
           "- http://example.com:8000/Hello.xml -> (problem)\n" ^
@@ -267,7 +269,8 @@ let suite = "0install">::: [
 
     let () =
       try ignore @@ run ["download"; "--offline"; (feed_dir +/ "selections.xml")]; assert false
-      with Safe_exception (msg, _) ->
+      with Safe_exn.T e ->
+        let msg = Safe_exn.msg e in
         assert_contains "Can't download as in offline mode:\nhttp://example.com:8000/Hello.xml 1" msg in
 
     let fake_slave = new fake_slave config in
@@ -309,7 +312,7 @@ let suite = "0install">::: [
 
     fake_system#unsetenv "DISPLAY";
     try ignore @@ run ["run"; "--gui"; "http://foo/d"]; assert false
-    with Safe_exception ("Can't use GUI because $DISPLAY is not set", _) -> ();
+    with Safe_exn.T e when Safe_exn.msg e = "Can't use GUI because $DISPLAY is not set" -> ();
 
     (* --dry-run must prevent us from using the GUI *)
     fake_system#putenv "DISPLAY" ":foo";

--- a/ocaml/tests/test_apps.ml
+++ b/ocaml/tests/test_apps.ml
@@ -3,6 +3,7 @@
  *)
 
 open Zeroinstall.General
+open Support
 open Support.Common
 open OUnit
 module U = Support.Utils
@@ -29,7 +30,7 @@ let suite = "apps">::: [
     let r = R.run url in
     let () =
       try ignore @@ Apps.create_app config "/foo" r; assert false
-      with Safe_exception _ -> () in
+      with Safe_exn.T _ -> () in
 
     ignore @@ Apps.create_app config "hello" r;
 

--- a/ocaml/tests/test_download.ml
+++ b/ocaml/tests/test_download.ml
@@ -6,6 +6,7 @@
 
 open Zeroinstall
 open Zeroinstall.General
+open Support
 open Support.Common
 open OUnit
 
@@ -33,7 +34,7 @@ let parse_sels xml =
     |> Xmlm.make_input
     |> Q.parse_input None
     |> Zeroinstall.Selections.create
-  with Safe_exception _ as ex ->
+  with Safe_exn.T _ as ex ->
     reraise_with_context ex "... parsing %s" xml
 
 let get_sel_path config sel =

--- a/ocaml/tests/test_driver.ml
+++ b/ocaml/tests/test_driver.ml
@@ -4,6 +4,7 @@
 
 open OUnit
 
+open Support
 open Support.Common
 open Zeroinstall
 open Zeroinstall.General
@@ -183,7 +184,8 @@ let make_driver_test test_elem =
             Fake_system.assert_str_equal value (StringMap.find_safe name !actual_env)
           )
         )
-      with Safe_exception (msg, _) ->
+      with Safe_exn.T e ->
+        let msg = Safe_exn.msg e in
         let re = Str.regexp !expected_problem in
         if not (Str.string_match re msg 0) then
           assert_failure (Printf.sprintf "Expected error '%s' but got '%s'" !expected_problem msg) in

--- a/ocaml/tests/test_fetch.ml
+++ b/ocaml/tests/test_fetch.ml
@@ -2,6 +2,7 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
+open Support
 open Support.Common
 open Zeroinstall
 open Zeroinstall.General
@@ -145,7 +146,8 @@ let suite = "fetch">::: [
       try
         try_with ?digest @@ "<recipe><archive href='recipe-base.tgz' extract='recipe' size='305'/>" ^ xml ^ "</recipe>";
         assert (error = None);
-      with Safe_exception (msg, _) ->
+      with Safe_exn.T e ->
+        let msg = Safe_exn.msg e in
         let error = error |? lazy (raise_safe "Unexpected error '%s'" msg) in
         if not (Str.string_match (Str.regexp error) msg 0) then (
           raise_safe "Expected error '%s' but got '%s'" error msg
@@ -200,7 +202,8 @@ let suite = "fetch">::: [
             (* Is cached now *)
             let path = Stores.lookup_maybe config.system digests config.stores |? lazy (failwith "missing!") in
             assert (config.system#file_exists (path +/ testfile));
-      with Safe_exception (msg, _) ->
+      with Safe_exn.T e ->
+        let msg = Safe_exn.msg e in
         let error = error |? lazy (raise_safe "Unexpected error '%s'" msg) in
         if not (Str.string_match (Str.regexp error) msg 0) then (
           raise_safe "Expected error '%s' but got '%s'" error msg

--- a/ocaml/tests/test_gpg.ml
+++ b/ocaml/tests/test_gpg.ml
@@ -2,6 +2,7 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
+open Support
 open Support.Common
 open OUnit
 open Zeroinstall.General
@@ -116,7 +117,7 @@ let suite = "gpg">::: [
     Lwt.catch
       (fun () -> G.import_key gpg "Bad key" >>= fun () -> assert false)
       (function
-        | Safe_exception _ -> Lwt.return ()
+        | Safe_exn.T _ -> Lwt.return ()
         | ex -> Lwt.fail ex
       )
   );
@@ -150,7 +151,8 @@ let suite = "gpg">::: [
            assert_failure expected
         )
         (function
-          | Safe_exception (msg, _) ->
+          | Safe_exn.T e ->
+            let msg = Safe_exn.msg e in
             Fake_system.assert_str_equal expected msg;
             Lwt.return ()
           | ex -> Lwt.fail ex

--- a/ocaml/tests/test_packagekit.ml
+++ b/ocaml/tests/test_packagekit.ml
@@ -5,6 +5,7 @@
 (* These tests actually run a dummy web-server. *)
 
 open Zeroinstall.General
+open Support
 open Support.Common
 open OUnit
 
@@ -83,7 +84,9 @@ let suite =
 
             let destroy =
               try Lwt_main.run (Pk_service.start [| 0; 8; 1 |])
-              with Safe_exception ("No D-BUS!", _) -> skip_if true "No D-BUS support compiled in"; assert false in
+              with Safe_exn.T e when Safe_exn.msg e = "No D-BUS!" ->
+                skip_if true "No D-BUS support compiled in"; assert false
+            in
             assert_equal 1 @@ test config fake_system;
             Fake_system.fake_log#assert_contains "confirm: The following components need to be installed using native packages.";
 

--- a/ocaml/tests/test_versions.ml
+++ b/ocaml/tests/test_versions.ml
@@ -4,6 +4,7 @@
 
 open OUnit
 open Zeroinstall
+open Support
 open Support.Common
 open Fake_system
 
@@ -14,7 +15,7 @@ let pv v =
 
 let invalid v =
   try ignore @@ pv v; assert false
-  with Safe_exception _ -> () 
+  with Safe_exn.T _ -> () 
 
 let dummy_impl = Impl.({
   qdom = Element.make_impl Support.Qdom.AttrMap.empty;
@@ -120,7 +121,7 @@ let suite = "versions">::: [
     try
       ignore @@ Version.parse_expr "1.1..2";
       assert false
-    with Safe_exception _ -> ()
+    with Safe_exn.T _ -> ()
   );
 
   "ranges2">:: (fun () ->

--- a/ocaml/zeroinstall/apps.ml
+++ b/ocaml/zeroinstall/apps.ml
@@ -3,6 +3,7 @@
  *)
 
 open General
+open Support
 open Support.Common
 module U = Support.Utils
 
@@ -88,7 +89,7 @@ let get_requirements (system:#filesystem) app_path =
   let path = app_path +/ "requirements.json" in
   path |> system#with_open_in [Open_rdonly; Open_binary] (fun ch ->
       try Requirements.of_json (Yojson.Basic.from_channel ~fname:path ch)
-      with Safe_exception _ as ex -> reraise_with_context ex "... parsing JSON file %s" path
+      with Safe_exn.T _ as ex -> reraise_with_context ex "... parsing JSON file %s" path
     )
 
 let set_last_checked system app_dir =

--- a/ocaml/zeroinstall/apps.mli
+++ b/ocaml/zeroinstall/apps.mli
@@ -34,7 +34,7 @@ val get_history : config -> app -> string list
 val get_times : #filesystem -> app -> app_times
 
 (** Get the current selections. Does not check whether they're still valid.
- * @raise Safe_exception if they're missing. *)
+ * @raise Safe_exn.T if they're missing. *)
 val get_selections_no_updates : #filesystem -> app -> Selections.t
 
 (** Get the current selections.

--- a/ocaml/zeroinstall/archive.ml
+++ b/ocaml/zeroinstall/archive.ml
@@ -3,6 +3,7 @@
  *)
 
 open General
+open Support
 open Support.Common
 module U = Support.Utils
 
@@ -106,7 +107,7 @@ let run_command ?cwd system args =
           let messages = String.trim @@ stdout ^ stderr in
           if messages = "" then Support.System.check_exit_status status;
           raise_safe "Command failed: %s" messages
-    with Safe_exception _ as ex ->
+    with Safe_exn.T _ as ex ->
       reraise_with_context ex "... extracting archive with: %s" (Support.Logging.format_argv_for_logging args)
   )
 

--- a/ocaml/zeroinstall/archive.mli
+++ b/ocaml/zeroinstall/archive.mli
@@ -7,11 +7,11 @@
 type mime_type = string
 
 (* Guess the MIME type from the URL's extension.
- * @raise Safe_exception if the extension is unknown. *)
+ * @raise Safe_exn.T if the extension is unknown. *)
 val type_from_url : string -> mime_type
 
 (* Check we have the needed software to extract from an archive of the given type.
- * @raise Safe_exception with a suitable message if not. *)
+ * @raise Safe_exn.T with a suitable message if not. *)
 val check_type_ok : Support.Common.system -> mime_type -> unit
 
 (** Unpack [archive] to a temporary directory and then move things into [destdir], checking that we're not following symlinks at each

--- a/ocaml/zeroinstall/command.ml
+++ b/ocaml/zeroinstall/command.ml
@@ -2,6 +2,7 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
+open Support
 open Support.Common
 module U = Support.Utils
 
@@ -46,7 +47,7 @@ let rec expand ~env = function
 let get_args elem env =
   try
     Element.arg_children elem >>= expand ~env
-  with Safe_exception _ as ex -> reraise_with_context ex "... expanding %a" Element.pp elem
+  with Safe_exn.T _ as ex -> reraise_with_context ex "... expanding %a" Element.pp elem
 
 let find_ex role impls =
   Selections.RoleMap.find role impls
@@ -111,4 +112,4 @@ let rec build_command ?main ?(dry_run=false) impls req env : string list =
       let runner_role = {Selections.iface = Element.interface runner; source = false} in
       let runner_req = {Selections.command = Some runner_command_name; role = runner_role} in
       build_command ~dry_run impls runner_req env @ runner_args @ args
-  with Safe_exception _ as ex -> reraise_with_context ex "... building command for %a" Selections.Role.pp role
+  with Safe_exn.T _ as ex -> reraise_with_context ex "... building command for %a" Selections.Role.pp role

--- a/ocaml/zeroinstall/distro_cache.ml
+++ b/ocaml/zeroinstall/distro_cache.ml
@@ -5,6 +5,7 @@
 (** A simple cache for storing key-value pairs on disk. Distributions may wish to use this to record the
     version(s) of each distribution package currently installed. *)
 
+open Support
 open Support.Common
 open General
 
@@ -127,7 +128,7 @@ let create_lazy config ~cache_leaf ~source ~if_missing =
           values |> List.iter (add_entry ch key)
         )
       )
-    with Safe_exception _ as ex -> reraise_with_context ex "... writing cache %s" data.cache_path in
+    with Safe_exn.T _ as ex -> reraise_with_context ex "... writing cache %s" data.cache_path in
   fun key ->
     ensure_valid config data;
     let entries =

--- a/ocaml/zeroinstall/driver.ml
+++ b/ocaml/zeroinstall/driver.ml
@@ -3,6 +3,7 @@
  *)
 
 open General
+open Support
 open Support.Common
 
 let (>|=) = Lwt.(>|=)
@@ -88,8 +89,8 @@ let solve_with_downloads config distro fetcher ~(watcher:#Progress.watcher) requ
       Lwt.catch
         (fun () -> download >|= fun fn -> (url, fn))
         (function
-          | Safe_exception (msg, _) ->
-            watcher#report url msg;
+          | Safe_exn.T e ->
+            watcher#report url (Safe_exn.msg e);
             Lwt.return (url, fun () -> ())
           | ex -> Lwt.fail ex (* or report this too? *)
         ) in

--- a/ocaml/zeroinstall/element.ml
+++ b/ocaml/zeroinstall/element.ml
@@ -7,6 +7,7 @@
  * http://0install.net/interface-spec.html
  * http://0install.net/selections-spec.html *)
 
+open Support
 open Support.Common
 open General
 open Constants
@@ -80,7 +81,7 @@ let parse_selections root =
           Q.child_nodes = !index |> StringMap.map_bindings (fun _ child -> child);
           Q.attrs = root.Q.attrs |> AttrMap.add_no_ns "command" "run"
         }
-      with Safe_exception _ as ex -> reraise_with_context ex "... migrating from old selections format"
+      with Safe_exn.T _ as ex -> reraise_with_context ex "... migrating from old selections format"
 
 let selections = ZI.map (fun x -> x) ~name:"selection"
 

--- a/ocaml/zeroinstall/element.mli
+++ b/ocaml/zeroinstall/element.mli
@@ -123,7 +123,7 @@ val distributions : [< `Package_impl] t -> string option
 (** {2 Commands} *)
 
 (** Find the <runner> child of this element (selection or command), if any.
- * @raise Safe_exception if there are multiple runners. *)
+ * @raise Safe_exn.T if there are multiple runners. *)
 val get_runner : [`Command] t -> [`Runner] t option
 val make_command : ?path:filepath -> ?shell_command:string -> source_hint:'a t option -> string -> [`Command] t
 val get_command : string -> [`Selection] t -> [`Command] t option
@@ -185,7 +185,7 @@ val quick_test_mtime : [`Selection] t -> int64 option
 
 (** {2 Error reporting} *)
 
-(** [raise_elem "Problem with" elem] raises a [Safe_exception] with the message "Problem with <element> at ..." *)
+(** [raise_elem "Problem with" elem] raises a [Safe_exn.T] with the message "Problem with <element> at ..." *)
 val raise_elem : ('a, unit, string, _ t -> 'b) format4 -> 'a
 
 (** Like [raise_elem], but writing a log record rather than raising an exception. *)

--- a/ocaml/zeroinstall/feed.ml
+++ b/ocaml/zeroinstall/feed.ml
@@ -5,6 +5,7 @@
 (** Parsing feeds *)
 
 open General
+open Support
 open Support.Common
 module Q = Support.Qdom
 module U = Support.Utils
@@ -89,7 +90,7 @@ let create_impl system ~local_dir state node =
 
   let (os, machine) =
     try Arch.parse_arch @@ default "*-*" @@ AttrMap.get_no_ns "arch" !s.attrs
-    with Safe_exception _ as ex -> reraise_with_context ex "... processing %a" Element.pp node in
+    with Safe_exn.T _ as ex -> reraise_with_context ex "... processing %a" Element.pp node in
 
   let stability =
     match AttrMap.get_no_ns FeedAttr.stability !s.attrs with

--- a/ocaml/zeroinstall/feed_cache.ml
+++ b/ocaml/zeroinstall/feed_cache.ml
@@ -5,6 +5,7 @@
 (** Caching downloaded feeds on disk *)
 
 open General
+open Support
 open Support.Common
 module Q = Support.Qdom
 module U = Support.Utils
@@ -134,7 +135,7 @@ let load_iface_config config uri : interface_config =
         match Paths.Config.(first (user_overrides uri)) config.paths with
         | None -> { stability_policy = None; extra_feeds = distro_feeds @ site_feeds }
         | Some path -> load path
-  with Safe_exception _ as ex -> reraise_with_context ex "... reading configuration settings for interface %s" uri
+  with Safe_exn.T _ as ex -> reraise_with_context ex "... reading configuration settings for interface %s" uri
 
 let add_import_elem feed_import =
   match feed_import.Feed.feed_type with
@@ -170,7 +171,7 @@ let get_cached_feed config = function
       try
         let root = Q.parse_file config.system path |> Element.parse_feed in
         Some (Feed.parse config.system root (Some path))
-      with Safe_exception _ as ex ->
+      with Safe_exn.T _ as ex ->
         log_warning ~ex "Can't read local file '%s'" path;
         None
   )

--- a/ocaml/zeroinstall/gui.ml
+++ b/ocaml/zeroinstall/gui.ml
@@ -5,6 +5,7 @@
 (** Manage the GUI sub-process. *)
 
 open General
+open Support
 open Support.Common
 
 module FeedAttr = Constants.FeedAttr
@@ -65,9 +66,9 @@ let get_fetch_info config impl =
               let pretty = U.format_size (Int64.of_float size) in
               (pretty, Printf.sprintf "Distribution package: need to download %s (%s bytes)" pretty (string_of_float size))
         end
-  with Safe_exception (msg, _) as ex ->
+  with Safe_exn.T e as ex ->
     log_warning ~ex "get_fetch_info";
-    ("ERROR", msg)
+    ("ERROR", Safe_exn.msg e)
 
 let have_source_for feed_provider iface =
   let master_feed = Feed_url.master_feed_of_iface iface in
@@ -191,7 +192,7 @@ let set_impl_stability config {Feed_url.feed; Feed_url.id} rating =
  * On error, report both stdout and stderr. *)
 let run_subprocess argv =
   log_info "Running %s" (Support.Logging.format_argv_for_logging (Array.to_list argv));
-  with_error_info
+  Safe_exn.with_info
     (fun f -> f "... executing %s" (Support.Logging.format_argv_for_logging (Array.to_list argv)))
     (fun () ->
       let command = (argv.(0), argv) in

--- a/ocaml/zeroinstall/gui.mli
+++ b/ocaml/zeroinstall/gui.mli
@@ -65,7 +65,7 @@ val get_bug_report_details : General.config -> role:Solver.role -> (bool * Solve
 
 (** Submit a bug report for this interface.
  * @return the response from the server (on success).
- * @raise Safe_exception on failure. *)
+ * @raise Safe_exn.T on failure. *)
 val send_bug_report : Sigs.iface_uri -> string -> string Lwt.t
 
 val run_test : General.config -> Distro.t -> (Selections.t -> string Lwt.t) -> (bool * Solver.Model.t) -> string Lwt.t

--- a/ocaml/zeroinstall/impl.ml
+++ b/ocaml/zeroinstall/impl.ml
@@ -2,6 +2,7 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
+open Support
 open Support.Common
 
 module U = Support.Utils
@@ -163,8 +164,8 @@ let make_version_restriction expr =
         method to_string = "version " ^ expr
       end
     )
-  with Safe_exception (ex_msg, _) as ex ->
-    let msg = Printf.sprintf "Can't parse version restriction '%s': %s" expr ex_msg in
+  with Safe_exn.T e as ex ->
+    let msg = Format.asprintf "Can't parse version restriction '%s': %s" expr (Safe_exn.msg e) in
     log_warning ~ex:ex "%s" msg;
     make_impossible_restriction msg
 

--- a/ocaml/zeroinstall/impl_provider.ml
+++ b/ocaml/zeroinstall/impl_provider.ml
@@ -3,6 +3,7 @@
  *)
 
 open General
+open Support
 open Support.Common
 module U = Support.Utils
 
@@ -247,7 +248,7 @@ class default_impl_provider config (feed_provider : Feed_provider.feed_provider)
       | `Package_impl {package_state;_} -> package_state = `Installed
       | `Local_impl path -> config.system#file_exists path
       | `Cache_impl {digests;_} -> Stores.check_available cached_digests digests
-    with Safe_exception _ as ex ->
+    with Safe_exn.T _ as ex ->
       log_warning ~ex "Can't test whether impl is available: %a" Impl.pp impl;
       false in
 
@@ -263,7 +264,7 @@ class default_impl_provider config (feed_provider : Feed_provider.feed_provider)
         );
         feed
       ) else None
-    with Safe_exception _ as ex ->
+    with Safe_exn.T _ as ex ->
       log_warning ~ex "Failed to get implementations";
       let feed_url = Feed_url.format_url feed_import.Feed.feed_src in
       problem (Printf.sprintf "Error getting imported feed '%s': %s" feed_url (Printexc.to_string ex));

--- a/ocaml/zeroinstall/manifest.ml
+++ b/ocaml/zeroinstall/manifest.ml
@@ -2,6 +2,7 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
+open Support
 open Support.Common
 
 module H = Support.Hash
@@ -155,7 +156,7 @@ let add_manifest_file system alg dir =
     );
     system#chmod dir 0o555;
     hash_manifest alg manifest_contents
-  with Safe_exception _ as ex -> reraise_with_context ex "... adding .manifest file in %s" dir
+  with Safe_exn.T _ as ex -> reraise_with_context ex "... adding .manifest file in %s" dir
 
 let algorithm_names = [
   "sha1";
@@ -301,7 +302,7 @@ let verify system ~digest dir =
         Buffer.add_string b "The .manifest file matches neither of the other digests. Odd."
     end;
 
-    raise (Safe_exception (String.trim @@ Buffer.contents b, ref []))
+    Safe_exn.failf "%s" (String.trim @@ Buffer.contents b)
   )
 
 let parse_manifest manifest_data =

--- a/ocaml/zeroinstall/packagekit.ml
+++ b/ocaml/zeroinstall/packagekit.ml
@@ -2,6 +2,7 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
+open Support
 open Support.Common
 module U = Support.Utils
 
@@ -71,7 +72,7 @@ let resolve proxy package_names =
   Lwt.catch
     (fun () -> Packagekit_stubs.summaries proxy ~package_names (add_package details))
     (function
-      | Safe_exception _ as ex ->
+      | Safe_exn.T _ as ex ->
         (* This is a bit broken. PackageKit seems to abort on the first unknown package, so we
          * lose the remaining results. Still, something is better than nothing... *)
         log_debug ~ex "Error resolving %s with PackageKit" (String.concat "," package_names);

--- a/ocaml/zeroinstall/packagekit_stubs.ml
+++ b/ocaml/zeroinstall/packagekit_stubs.ml
@@ -4,6 +4,7 @@
 
 (** There are several different versions of the PackageKit API. This module provides a consistent interface to them. *)
 
+open Support
 open Support.Common
 
 (** [keep ~switch value] prevents [value] from being garbage collected until the switch is turned off.
@@ -117,9 +118,9 @@ module Transaction = struct
         error := None;
         match err with
         | None when status = "success" -> Lwt.wakeup waker ()
-        | None -> Lwt.wakeup_exn waker (Safe_exception ("PackageKit transaction failed: " ^ status, ref []))
+        | None -> Lwt.wakeup_exn waker (Safe_exn.v "PackageKit transaction failed: %s" status)
         | Some (code, msg) ->
-            let ex = Safe_exception (code ^ ": " ^ msg, ref []) in
+            let ex = Safe_exn.v "%s: %s" code msg in
             Lwt.wakeup_exn waker ex in
 
       let error (code, details) =

--- a/ocaml/zeroinstall/selections.ml
+++ b/ocaml/zeroinstall/selections.ml
@@ -2,6 +2,7 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
+open Support
 open Support.Common
 
 module U = Support.Utils
@@ -179,7 +180,7 @@ let collect_bindings t =
 
   t |> iter (fun role node ->
     try process_impl role node
-    with Safe_exception _ as ex -> reraise_with_context ex "... getting bindings from selection %a" Role.pp role
+    with Safe_exn.T _ as ex -> reraise_with_context ex "... getting bindings from selection %a" Role.pp role
   );
   List.rev !bindings
 

--- a/ocaml/zeroinstall/solver.ml
+++ b/ocaml/zeroinstall/solver.ml
@@ -6,6 +6,7 @@
  * This instantiates the [Solver_core] functor with the concrete 0install types. *)
 
 open General
+open Support
 open Support.Common
 module U = Support.Utils
 module Qdom = Support.Qdom
@@ -308,7 +309,7 @@ let solve_for config feed_provider requirements =
         match do_solve root_req ~closest_match:true with
         | Some result -> (false, result)
         | None -> failwith "No solution, even with closest_match!"
-  with Safe_exception _ as ex -> reraise_with_context ex "... solving for interface %s" requirements.Requirements.interface_uri
+  with Safe_exn.T _ as ex -> reraise_with_context ex "... solving for interface %s" requirements.Requirements.interface_uri
 
 (** Create a <selections> document from the result of a solve.
  * The use of Maps ensures that the inputs will be sorted, so we will have a stable output.

--- a/ocaml/zeroinstall/stores.ml
+++ b/ocaml/zeroinstall/stores.ml
@@ -5,6 +5,7 @@
 (** Managing cached implementations *)
 
 open General
+open Support
 open Support.Common
 module Q = Support.Qdom
 module U = Support.Utils
@@ -218,7 +219,7 @@ let add_with_helper config required_digest tmpdir =
               Support.System.check_exit_status status;
               log_info "Added succcessfully using helper.";
               Lwt.return `Success
-            with Safe_exception _ as ex ->
+            with Safe_exn.T _ as ex ->
               log_warning ~ex "Error running %s" helper;
               Lwt.return `No_helper
           )

--- a/ocaml/zeroinstall/stores.mli
+++ b/ocaml/zeroinstall/stores.mli
@@ -29,7 +29,7 @@ val best_digest : Manifest.digest list -> Manifest.digest
 (** Recursively set permissions:
   * Directories and executable files become 0o555.
   * Other files become 0o444.
-  * @raise Safe_exception if there are special files or files with special mode bits set *)
+  * @raise Safe_exn.T if there are special files or files with special mode bits set *)
 val fixup_permissions : #filesystem -> filepath -> unit
 
 (** Create a temporary directory in the directory where we would store a new implementation.

--- a/ocaml/zeroinstall/version.ml
+++ b/ocaml/zeroinstall/version.ml
@@ -4,6 +4,7 @@
 
 (** Parsing version numbers *)
 
+open Support
 open Support.Common
 
 type modifier =
@@ -116,7 +117,7 @@ let parse_expr s =
   try
     let tests = List.map parse_range (Str.split_delim re_pipe s) in
     fun v -> List.exists (fun t -> t v) tests
-  with Safe_exception _ as ex -> reraise_with_context ex "... parsing version expression '%s'" s
+  with Safe_exn.T _ as ex -> reraise_with_context ex "... parsing version expression '%s'" s
 
 (** Any distribution-provided version number is capped to this.
  * Prevents them wrapping around (very large numbers are usually hashes anyway).

--- a/ocaml/zeroinstall/version.mli
+++ b/ocaml/zeroinstall/version.mli
@@ -20,7 +20,7 @@ type version_expr = t -> bool
     The parsed format can be compared using the regular comparison operators.
      - Version := DottedList ("-" Mod DottedList?)*
      - DottedList := (Integer ("." Integer)* )
-    @raise Safe_exception if the string isn't a valid version
+    @raise Safe_exn.T if the string isn't a valid version
  *)
 val parse : string -> t
 val to_string : t -> string


### PR DESCRIPTION
Also, add an mli file and make the payload type abstract.

Some places that previously only displayed the message now include the context if present (often it isn't, so this makes no difference).

This allows other things that use exceptions to be moved out of Common.