### PR TITLE
Move Env to Support.Env

### DIFF
--- a/ocaml/man.ml
+++ b/ocaml/man.ml
@@ -9,7 +9,6 @@ open Support
 open Support.Common
 open Zeroinstall.General
 module U = Support.Utils
-module Env = Zeroinstall.Env
 
 (** Exec the man command. Never returns. *)
 let exec_man config ?env args =

--- a/ocaml/support.mlpack
+++ b/ocaml/support.mlpack
@@ -2,6 +2,7 @@ Argparse
 Base64
 Basedir
 Common
+Env
 Gpg
 Hash
 Locale

--- a/ocaml/support/common.ml
+++ b/ocaml/support/common.ml
@@ -5,7 +5,6 @@
 (** Common types and functions. This module is intended to be opened. *)
 
 type filepath = string
-type varname = string
 
 (** Raise this to exit the program. Allows finally blocks to run. *)
 exception System_exit of int
@@ -64,7 +63,7 @@ class type processes =
 
 class type environment =
   object
-    method getenv : varname -> string option
+    method getenv : Env.name -> string option
     method environment : string array
   end
 

--- a/ocaml/support/env.ml
+++ b/ocaml/support/env.ml
@@ -2,20 +2,22 @@
  * See the README file for details, or visit http://0install.net.
  *)
 
-(** Environment variables (generic support code) *)
-
-open Support
-
 type t = string XString.Map.t
+
+type name = string
 
 let empty = XString.Map.empty
 
-let of_array arr =
-  arr |> Array.fold_left (fun acc line ->
-      match Str.bounded_split_delim Support.XString.re_equals line 2 with
-      | [key; value] -> XString.Map.add key value acc
-      | _ -> failwith (Printf.sprintf "Invalid environment mapping '%s'" line)
-    ) XString.Map.empty
+let parse_binding line =
+  match Str.bounded_split_delim XString.re_equals line 2 with
+  | [key; value] -> (key, value)
+  | _ -> failwith (Printf.sprintf "Invalid environment mapping '%s'" line)
+
+let of_array =
+  XString.Map.empty
+  |> Array.fold_left @@ fun acc line ->
+  let key, value = parse_binding line in
+  XString.Map.add key value acc
 
 let put = XString.Map.add
 let unset = XString.Map.remove
@@ -31,5 +33,5 @@ let to_array t =
   let arr = Array.make len "" in
   let item_to_array key value i = (arr.(i) <- key ^ "=" ^ value; i + 1) in
   let check_len = XString.Map.fold item_to_array t 0 in
-  assert (len == check_len);
+  assert (len = check_len);
   arr

--- a/ocaml/support/env.mli
+++ b/ocaml/support/env.mli
@@ -4,15 +4,15 @@
 
 (** Environment variables (generic support code) *)
 
-open Support.Common
-
 type t
 
+type name = string
+
 val empty : t
-val put : varname -> string -> t -> t
-val get : varname -> t -> string option
-val get_exn : varname -> t -> string
-val unset : varname -> t -> t
+val put : name -> string -> t -> t
+val get : name -> t -> string option
+val get_exn : name -> t -> string
+val unset : name -> t -> t
 
 val of_array : string array -> t
 val to_array : t -> string array

--- a/ocaml/zeroinstall.mlpack
+++ b/ocaml/zeroinstall.mlpack
@@ -18,7 +18,6 @@ Downloader
 Driver
 Dry_run
 Element
-Env
 Escape
 Exec
 Feed

--- a/ocaml/zeroinstall/binding.ml
+++ b/ocaml/zeroinstall/binding.ml
@@ -4,6 +4,7 @@
 
 (** Binding elements: <environment>, <executable-in-*>, <binding> *)
 
+open Support
 open Support.Common
 
 type which_end = Prepend | Append
@@ -18,7 +19,7 @@ type env_source =
   | Value of string
 
 type exec_type = InPath | InVar
-type env_binding = {var_name: varname; mode: mode; source: env_source}
+type env_binding = {var_name: Env.name; mode: mode; source: env_source}
 type exec_binding = {exec_type: exec_type; name: string; command: string}
 
 type binding =

--- a/ocaml/zeroinstall/command.mli
+++ b/ocaml/zeroinstall/command.mli
@@ -4,6 +4,7 @@
 
 (** <command> elements *)
 
+open Support
 open Support.Common
 
 (** [build_command sels reqs env] is the argv for the command to run to execute [sels] as requested by [reqs].


### PR DESCRIPTION
Allows removing varname from Common.
Also, tidied the code slightly.