### PR TITLE
Rename runenv variables due to Python breakage (for old Python branch)

### DIFF
--- a/zeroinstall/injector/_runenv.py
+++ b/zeroinstall/injector/_runenv.py
@@ -10,5 +10,5 @@ import os, sys
 def main():
 	envname = os.path.basename(sys.argv[0])
 	import json
-	args = json.loads(os.environ["0install-runenv-" + envname])
+	args = json.loads(os.environ["py_install_runenv_" + envname])
 	os.execv(args[0], args + sys.argv[1:])

--- a/zeroinstall/injector/run.py
+++ b/zeroinstall/injector/run.py
@@ -264,7 +264,7 @@ class Setup(object):
 			os.environ["ZEROINSTALL_RUNENV_ARGS_" + name] = support.windows_args_escape(args[1:])
 		else:
 			import json
-			os.environ["0install-runenv-" + name] = json.dumps(args)
+			os.environ["py_install_runenv_" + name] = json.dumps(args)
 
 	def _check_runenv(self):
 		# Create the runenv.py helper script under ~/.cache if missing or out-of-date


### PR DESCRIPTION
Recent versions of Python silently fail to pass on environment variables starting with `0` or containing dashes.