### PR TITLE
Fix check for HTTP Location header

### DIFF
--- a/ocaml/support/dune
+++ b/ocaml/support/dune
@@ -55,7 +55,7 @@ let dune = String.concat "" [ {|
    (name        support) |};
    c_flags; {|
    (c_names     utils |}; extra_stubs; {| )
-   (libraries   lwt lwt.unix sha str xmlm))
+   (libraries   lwt lwt.unix sha str xmlm yojson))
 |}; windres ]
 
 let () =

--- a/ocaml/support/json.ml
+++ b/ocaml/support/json.ml
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "-3"]
+
+type t = Yojson.Basic.json

--- a/ocaml/tests/server.ml
+++ b/ocaml/tests/server.ml
@@ -105,7 +105,7 @@ let start_server system =
         | `Give404 -> send_error to_client 404 ("Missing: " ^ leaf)
         | `Redirect redirect_target ->
             send_response to_client 302 >>= fun () ->
-            send_header to_client "Location" redirect_target >>= fun () ->
+            send_header to_client "LocatioN" redirect_target >>= fun () ->
             let msg = "<html>\n\
                          <head>\n\
                           <title>302 Found</title>\n\

--- a/ocaml/zeroinstall/downloader.ml
+++ b/ocaml/zeroinstall/downloader.ml
@@ -50,7 +50,7 @@ let download_no_follow ~cancelled ?size ?modification_time ?(start_offset=Int64.
   Lwt.catch (fun () ->
     let redirect = ref None in
     let check_header header =
-      if XString.starts_with header "Location:" then (
+      if XString.starts_with (String.lowercase_ascii header) "location:" then (
         redirect := Some (XString.tail header 9 |> String.trim)
       );
       String.length header in

--- a/ocaml/zeroinstall/exec.ml
+++ b/ocaml/zeroinstall/exec.ml
@@ -29,7 +29,7 @@ class launcher_builder config script =
 
     method setenv name command_argv env =
       let open Yojson.Basic in
-      let json :json = `List (List.map (fun a -> `String a) command_argv) in
+      let json : Json.t = `List (List.map (fun a -> `String a) command_argv) in
       let envname = "zeroinstall_runenv_" ^ name in
       let value = to_string json in
       log_info "%s=%s" envname value;

--- a/ocaml/zeroinstall/json_connection.ml
+++ b/ocaml/zeroinstall/json_connection.ml
@@ -19,7 +19,7 @@ let read_line ch =
 
 (* Read the next chunk from the channel.
    Returns [None] if the channel was closed. *)
-let read_chunk ch : J.json option Lwt.t =
+let read_chunk ch : Json.t option Lwt.t =
   read_line ch >>= function
   | None -> Lwt.return None
   | Some size ->
@@ -40,7 +40,7 @@ let read_xml_chunk ch =
       let buf = Bytes.unsafe_to_string buf in
       Q.parse_input None (Xmlm.make_input (`String (0, buf)))
 
-type opt_xml = [J.json | `WithXML of J.json * Q.element ]
+type opt_xml = [Json.t | `WithXML of Json.t * Q.element ]
 
 type t = {
   from_peer : Lwt_io.input_channel;
@@ -49,7 +49,7 @@ type t = {
   mutable last_ticket : int64;
 }
 
-type 'a handler = (string * Yojson.Basic.json list) -> [opt_xml | `Bad_request] Lwt.t
+type 'a handler = (string * Json.t list) -> [opt_xml | `Bad_request] Lwt.t
 
 let send_json t ?xml request : unit Lwt.t =
   let data = J.to_string request in
@@ -78,7 +78,7 @@ let handle_invoke t ~handle_request ticket op args () =
   Lwt.catch
     (fun () ->
       handle_request (op, args) >|= function
-      | #J.json as json ->
+      | #Json.t as json ->
           ([`String "ok"; json], None)
       | `WithXML (json, attached_xml) ->
           ([`String "ok+xml"; json], Some attached_xml)
@@ -159,4 +159,4 @@ let server ~api_version ~from_peer ~to_peer make_handler =
 
 let pp_opt_xml f = function
   | `WithXML (json, _) -> Format.fprintf f "%s+XML" (J.to_string json)
-  | #J.json as json -> Format.pp_print_string f (J.to_string json)
+  | #Json.t as json -> Format.pp_print_string f (J.to_string json)

--- a/ocaml/zeroinstall/json_connection.mli
+++ b/ocaml/zeroinstall/json_connection.mli
@@ -15,10 +15,12 @@
  * in the corresponding "return" or "fail" response.
  *)
 
+open Support
+
 type t
 
-type opt_xml = [Yojson.Basic.json | `WithXML of Yojson.Basic.json * Support.Qdom.element ]
-type 'a handler = (string * Yojson.Basic.json list) -> [opt_xml | `Bad_request] Lwt.t
+type opt_xml = [Json.t | `WithXML of Json.t * Qdom.element ]
+type 'a handler = (string * Json.t list) -> [opt_xml | `Bad_request] Lwt.t
 
 val client :
   from_peer:Lwt_io.input_channel ->
@@ -38,7 +40,7 @@ val server :
   t * unit Lwt.t
 (** Like [client], except that the server starts by sending the version number rather than reading it. *)
 
-val invoke : t -> ?xml:Support.Qdom.element -> string -> Yojson.Basic.json list -> opt_xml Lwt.t
-val notify : t -> ?xml:Support.Qdom.element -> string -> Yojson.Basic.json list -> unit Lwt.t
+val invoke : t -> ?xml:Qdom.element -> string -> Json.t list -> opt_xml Lwt.t
+val notify : t -> ?xml:Qdom.element -> string -> Json.t list -> unit Lwt.t
 
 val pp_opt_xml : Format.formatter -> opt_xml -> unit

--- a/ocaml/zeroinstall/requirements.mli
+++ b/ocaml/zeroinstall/requirements.mli
@@ -20,5 +20,5 @@ type t = {
 val run : Sigs.iface_uri -> t
 (** [run iface] is a requirement to run [iface] with no restrictions. *)
 
-val of_json : Yojson.Basic.json -> t
-val to_json : t -> Yojson.Basic.json
+val of_json : Json.t -> t
+val to_json : t -> Json.t


### PR DESCRIPTION
This should be case insensitive. Error was:

    info: Download failed: Downloaded archive has incorrect size.
    URL: https://downloads.sourceforge.net/project/zero-install/0template/0.6/0template-0.6.tar.bz2
    Expected: 17585 bytes
    Received: 371 bytes

This might have been caused by using HTTP/2.

Reported by Nick Sabalausky. Fixes https://github.com/0install/0template/issues/14.

Also, suppress some Yojson deprecation warnings.