### PR TITLE
Update Travis to use Ubuntu/Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 sudo: required
-dist: trusty
+dist: xenial
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash .travis-extra-deps.sh
 env:


### PR DESCRIPTION
Maybe this will fix the gnutls errors, e.g.

    Error downloading 'https://downloads.sourceforge.net/project/zero-install/0install/2.14/0install-linux-x86_64-2.14.tar.bz2': gnutls_handshake() failed: Handshake failed