### PR TITLE
Don't abort if we can't save new app selections

### DIFF
--- a/ocaml/zeroinstall/apps.ml
+++ b/ocaml/zeroinstall/apps.ml
@@ -205,7 +205,13 @@ let check_for_updates tools app_path sels =
           return sels
       | Some new_sels ->
           log_info "Quick solve succeeded; saving new selections";
-          set_selections config app_path new_sels ~touch_last_checked:false;
+          begin try
+              set_selections config app_path new_sels ~touch_last_checked:false;
+            with Safe_exn.T e ->
+              log_warning "Failed to save new selections for %S: %a"
+                (Filename.basename app_path)
+                Safe_exn.pp e
+          end;
           return new_sels
       | None when unavailable_sels ->
           log_info "Quick solve failed; we need to download something";


### PR DESCRIPTION
Just log a warning. Otherwise, you can't run an application at all if e.g. the filesystem is read-only, or we are running inside a sandbox (e.g. when an opam build recursively calls the opam binary).