### PR TITLE
More fixes for the old Python version

### DIFF
--- a/ZeroInstall.xml
+++ b/ZeroInstall.xml
@@ -46,7 +46,7 @@ interfere with those provided by the distribution.
 
     <restricts interface="http://repo.roscidus.com/python/python" version="2.6..!3 | 3.2.2..!3.7"/>
 
-    <requires interface="http://repo.roscidus.com/python/python-gobject" os="POSIX"/>
+    <requires interface="http://repo.roscidus.com/python/python-gobject"/>
 
     <requires interface="http://0install.net/2012/interfaces/0install-runenv-cli.xml" os="Windows">
       <environment insert="runenv.cli.template" mode="replace" name="ZEROINSTALL_CLI_TEMPLATE"/>

--- a/ZeroInstall.xml
+++ b/ZeroInstall.xml
@@ -44,7 +44,7 @@ interfere with those provided by the distribution.
       <executable-in-var name="ZEROINSTALL_GPG"/>
     </requires>
 
-    <restricts interface="http://repo.roscidus.com/python/python" version="2.6..!3 | 3.2.2.."/>
+    <restricts interface="http://repo.roscidus.com/python/python" version="2.6..!3 | 3.2.2..!3.7"/>
 
     <requires interface="http://repo.roscidus.com/python/python-gobject" os="POSIX"/>
 

--- a/ZeroInstall.xml
+++ b/ZeroInstall.xml
@@ -53,6 +53,6 @@ interfere with those provided by the distribution.
       <version not-before="2.0.2"/>
     </requires>
 
-    <implementation id="." version="2.3.5-post"/>
+    <implementation id="." released="2019-09-11" version="2.3.6"/>
   </group>
 </interface>

--- a/ZeroInstall.xml
+++ b/ZeroInstall.xml
@@ -53,6 +53,6 @@ interfere with those provided by the distribution.
       <version not-before="2.0.2"/>
     </requires>
 
-    <implementation id="." released="2019-09-11" version="2.3.6"/>
+    <implementation id="." version="2.3.6-post"/>
   </group>
 </interface>

--- a/zeroinstall/0launch-gui/gui.py
+++ b/zeroinstall/0launch-gui/gui.py
@@ -8,7 +8,7 @@ from zeroinstall.injector import handler, download
 gobject = tasks.get_loop().gobject
 glib = tasks.get_loop().glib
 
-version = '2.3.5'
+version = '2.3.6'
 
 class GUIHandler(handler.Handler):
 	dl_callbacks = None		# Download -> [ callback ]

--- a/zeroinstall/__init__.py
+++ b/zeroinstall/__init__.py
@@ -13,7 +13,7 @@ The Python implementation of the Zero Install injector is divided into five sub-
 @var _: a function for translating strings using the zero-install domain (for use internally by Zero Install)
 """
 
-version = '2.3.5'
+version = '2.3.6'
 
 import logging
 

--- a/zeroinstall/injector/gpg.py
+++ b/zeroinstall/injector/gpg.py
@@ -103,7 +103,7 @@ class ErrSig(Signature):
 	"""Error while checking a signature."""
 	KEYID = 0
 	ALG = 1
-	RC = -1
+	RC = 5
 
 	def __str__(self):
 		"""@rtype: str"""


### PR DESCRIPTION
- We can't use Python 3.7 as `async` is now a keyword.
- GnuPG's output format has changed (extra column).