### PR TITLE
Use new keylookup.0install.net address for key lookups

### DIFF
--- a/ocaml/tests/test_0install.ml
+++ b/ocaml/tests/test_0install.ml
@@ -72,7 +72,7 @@ class fake_slave _config =
 
   let handle_download ?if_slow:_ ?size:_ ?modification_time:_ ch url =
     let contents =
-      if XString.starts_with url "https://keylookup.appspot.com/key/" then (
+      if XString.starts_with url "https://keylookup.0install.net/key/" then (
         "<key-lookup><item vote='good'>Looks legit</item></key-lookup>"
       ) else (
         XString.Map.find_safe url !pending_feed_downloads

--- a/ocaml/zeroinstall/config.ml
+++ b/ocaml/zeroinstall/config.ml
@@ -59,7 +59,7 @@ let load_config config =
   | None -> ()
   | Some path -> Support.Utils.parse_ini config.system handle_ini_mapping path
 
-let default_key_info_server = Some "https://keylookup.appspot.com"
+let default_key_info_server = Some "https://keylookup.0install.net"
 
 (** [get_default_config path_to_0install] creates a configuration from the current environment.
     [path_to_0install] is used when creating launcher scripts. If it contains no slashes, then


### PR DESCRIPTION
Google just announced that they will start requiring a credit card for AppEngine apps, so migrate to new host.