### PR TITLE
Make transitive OCaml library dependencies explicit

### DIFF
--- a/0install.opam
+++ b/0install.opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_react"
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}
-  "dune" {build}
+  "dune"
   "cppo" {build}
 ]
 depopts: ["obus" "lablgtk" "lwt_glib"]

--- a/ocaml/cli/dune
+++ b/ocaml/cli/dune
@@ -2,4 +2,4 @@
  (name        zeroinstall_cli)
  (modules_without_implementation options)
  (wrapped     false)
- (libraries   zeroinstall))
+ (libraries   zeroinstall support yojson xmlm lwt lwt.unix curl))

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -6,14 +6,14 @@
  (ocamlc_flags   -linkall -custom)
  (link_flags  (:include support/extra_objects.sexp))
  (package     0install)
- (libraries   zeroinstall_cli zeroinstall))
+ (libraries   zeroinstall_cli zeroinstall support))
 
 (executable
  (public_name 0install-runenv.exe)
  (name        runenv)
  (modules     runenv)
  (link_flags  (:include support/extra_objects.sexp))
- (libraries   zeroinstall_cli zeroinstall))
+ (libraries   zeroinstall_cli zeroinstall support))
 
 (install
   (section bin)

--- a/ocaml/gui_gtk/dune
+++ b/ocaml/gui_gtk/dune
@@ -17,7 +17,7 @@ let plugin_ext =
 let dune = {|
   (library
    (name        gui_gtk_lib)
-   (libraries   lablgtk2 lwt_glib zeroinstall))
+   (libraries   lablgtk2 lwt_glib zeroinstall support lwt lwt.unix lwt_react))
 
   (rule
     (targets gui_gtk.cmxs)

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -13,4 +13,4 @@
   (deps (source_tree data)
         (alias ../../install)     ; Build the GTK plugin if possible
         0install%{ext_exe} 0install-runenv.exe)
-  (libraries oUnit zeroinstall zeroinstall_cli))
+  (libraries oUnit zeroinstall zeroinstall_cli support lwt lwt.unix lwt_react xmlm yojson))

--- a/ocaml/zeroinstall/dune
+++ b/ocaml/zeroinstall/dune
@@ -1,7 +1,7 @@
 (library
  (name        zeroinstall)
  (modules_without_implementation feed_provider progress sigs ui)
- (libraries curl curl.lwt dynlink lwt_react support yojson
+ (libraries curl curl.lwt dynlink lwt lwt.unix react lwt_react support yojson xmlm
             (select dbus.ml from
              (obus.network-manager
               obus.notification    -> dbus.with.ml)


### PR DESCRIPTION
Allows setting `(implicit_transitive_deps false)` in `dune-project`, which will be the default for Dune 2. However, that requires dune >= 1.7, and Debian only has 1.6, so don't turn that on yet.