### PR TITLE
Fix detection of obus library

### DIFF
--- a/.travis-extra-deps.sh
+++ b/.travis-extra-deps.sh
@@ -18,7 +18,7 @@ EOF
   sudo installer -verbose -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
   brew update &> /dev/null
   brew unlink python	# Python 3 conflicts with Python 2's /usr/local/bin/2to3-2 file
-  brew upgrade gnupg
+  brew upgrade gnupg wget
   brew install gtk+ pygobject
   export PKG_CONFIG_PATH=/usr/local/Library/Homebrew/os/mac/pkgconfig/10.9:/usr/lib/pkgconfig
 }

--- a/ocaml/cli/common_options.ml
+++ b/ocaml/cli/common_options.ml
@@ -46,13 +46,15 @@ let show_version f system =
   let prog = if XString.starts_with prog "0launch" then "0launch" else "0install" in
   Format.fprintf f
     "%s (zero-install) %s@,\
-     Copyright (C) 2016 Thomas Leonard@\n\
+     Copyright (C) 2019 Thomas Leonard@\n\
      This program comes with ABSOLUTELY NO WARRANTY,@ \
      to the extent permitted by law.@ \
      You may redistribute copies of this program@ \
      under the terms of the GNU Lesser General Public License.@ \
-     For more information about these matters, see the file named COPYING.@."
+     For more information about these matters, see the file named COPYING.@.\
+     Compiled with D-Bus support: %b@."
      prog Zeroinstall.About.version
+     Zeroinstall.Dbus.have_dbus
 
 let show_help (system:system) valid_options help f extra_fn =
   let prog = Filename.basename system#argv.(0) in

--- a/ocaml/zeroinstall/dbus.with.ml
+++ b/ocaml/zeroinstall/dbus.with.ml
@@ -52,3 +52,5 @@ let system () =
       log_debug ~ex "Failed to get D-BUS system bus";
       return (`Error "Failed to get D-BUS system bus")
     )
+
+let have_dbus = true

--- a/ocaml/zeroinstall/dbus.without.ml
+++ b/ocaml/zeroinstall/dbus.without.ml
@@ -169,3 +169,5 @@ module OBus_signal =
     let make _signal = no_dbus
     let emit _info _obj ?peer:_ = no_dbus
   end
+
+let have_dbus = false

--- a/ocaml/zeroinstall/dune
+++ b/ocaml/zeroinstall/dune
@@ -3,6 +3,8 @@
  (modules_without_implementation feed_provider progress sigs ui)
  (libraries curl curl.lwt dynlink lwt lwt.unix react lwt_react support yojson xmlm
             (select dbus.ml from
+             (obus.network_manager
+              obus.notification    -> dbus.with.ml)
              (obus.network-manager
               obus.notification    -> dbus.with.ml)
              (                     -> dbus.without.ml))))

--- a/ocaml/zeroinstall/packagekit_stubs.ml
+++ b/ocaml/zeroinstall/packagekit_stubs.ml
@@ -177,7 +177,10 @@ let connect lang_spec =
           | Dbus.OBus_bus.Service_unknown msg | Dbus.OBus_error.Unknown_object msg ->
             log_info "PackageKit not available: %s" msg;
             Lwt.return (`Unavailable (Printf.sprintf "PackageKit not available: %s" msg))
-          | ex -> Lwt.fail ex
+          | ex ->
+            (* obus 1.2.0 raises `E` *)
+            log_info ~ex "PackageKit not available";
+            Lwt.return (`Unavailable (Printf.sprintf "PackageKit not available: %s" (Printexc.to_string ex)))
         )
 
 let create_transaction t =


### PR DESCRIPTION
We looked for `obus.network-manager`, but that got renamed to `obus.network_manager` when obus converted to dune.

Also, show whether we were compiled with D-BUS support in the `--version` output.