### PR TITLE
Build and test static binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+dist
+static
+_build

--- a/.travis-extra-deps.sh
+++ b/.travis-extra-deps.sh
@@ -1,36 +1,42 @@
 #!/bin/bash
-set -eux
-# Install OCaml and OPAM PPAs
-install_on_ubuntu () {
-  sudo apt-get install -qq time libgtk2.0-dev libcurl4-openssl-dev python-gobject-2
-}
+if [ "$STATIC_DIST" == true ]; then
+  set -eux
+  make static-test
+else
+  set -eux
 
-install_on_osx () {
-  curl -OL "http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg"
-  # Disable sandboxing on OS X; it prevents the unit-tests from working.
-  cat > ~/.opamrc << EOF
-wrap-build-commands: []
-wrap-install-commands: []
-wrap-remove-commands: []
-required-tools: []
+  # Install OCaml and OPAM PPAs
+  install_on_ubuntu () {
+    sudo apt-get install -qq time libgtk2.0-dev libcurl4-openssl-dev python-gobject-2
+  }
+
+  install_on_osx () {
+    curl -OL "http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg"
+    # Disable sandboxing on OS X; it prevents the unit-tests from working.
+    cat > ~/.opamrc << EOF
+  wrap-build-commands: []
+  wrap-install-commands: []
+  wrap-remove-commands: []
+  required-tools: []
 EOF
-  sudo hdiutil attach XQuartz-2.7.6.dmg
-  sudo installer -verbose -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
-  brew update &> /dev/null
-  brew unlink python	# Python 3 conflicts with Python 2's /usr/local/bin/2to3-2 file
-  brew upgrade gnupg wget
-  brew install gtk+ pygobject
-  export PKG_CONFIG_PATH=/usr/local/Library/Homebrew/os/mac/pkgconfig/10.9:/usr/lib/pkgconfig
-}
+    sudo hdiutil attach XQuartz-2.7.6.dmg
+    sudo installer -verbose -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
+    brew update &> /dev/null
+    brew unlink python	# Python 3 conflicts with Python 2's /usr/local/bin/2to3-2 file
+    brew upgrade gnupg wget
+    brew install gtk+ pygobject
+    export PKG_CONFIG_PATH=/usr/local/Library/Homebrew/os/mac/pkgconfig/10.9:/usr/lib/pkgconfig
+  }
 
-case $TRAVIS_OS_NAME in
-  linux)
-         install_on_ubuntu ;;
-  osx)
-         install_on_osx ;;
-  *) echo "Unknown OS $TRAVIS_OS_NAME";
-     exit 1 ;;
-esac
+  case $TRAVIS_OS_NAME in
+    linux)
+	   install_on_ubuntu ;;
+    osx)
+	   install_on_osx ;;
+    *) echo "Unknown OS $TRAVIS_OS_NAME";
+       exit 1 ;;
+  esac
 
-# (downloaded by Travis install step)
-bash -e ./.travis-opam.sh
+  # (downloaded by Travis install step)
+  bash -e ./.travis-opam.sh
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,22 @@ script: bash .travis-extra-deps.sh
 env:
   global:
     - POST_INSTALL_HOOK="bash .travis-test-compile.sh"
-  matrix:
-    - OCAML_VERSION=4.05
-    - OCAML_VERSION=4.07
-    - OCAML_VERSION=4.08
-os:
-  - linux
-  - osx
+jobs:
+  include:
+    - env: OCAML_VERSION=4.05
+      os: linux
+    - env: OCAML_VERSION=4.08
+      os: linux
+    - env: OCAML_VERSION=4.09
+      os: linux
+
+    - env: STATIC_DIST=true
+      os: linux
+      services:
+        - docker
+
+    - env: OCAML_VERSION=4.08
+      os: osx
 addons:
   apt:
     update: true

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ default: all test
 
 clean:
 	dune clean --root=. --profile=${PROFILE}
-	rm -rf build dist
+	rm -rf build dist static/dist.tgz
 
 DOCS = README.md COPYING
 MANPAGES = 0launch.1 0store-secure-add.1 0store.1 0desktop.1 0install.1
@@ -81,3 +81,15 @@ install_local:
 .PHONY: all install test
 
 .PHONY: clean default
+
+.PHONY: static-test
+
+static/dist.tgz: static/Dockerfile
+	docker build -t talex5/0install-static-build -f static/Dockerfile .
+	docker run talex5/0install-static-build tar czf - dist > static/dist.tgz
+
+static-test-%: static/Dockerfile-test-% static/dist.tgz
+	docker build -f $< ./static -t 0install-test
+	docker run --rm -it -v "${SRCDIR}/static:/mnt:ro" 0install-test /mnt/run-tests.sh
+
+static-test: static-test-debian-10 static-test-fedora-30

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,0 +1,1 @@
+dist.tgz

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -1,0 +1,17 @@
+# Build on a really old system to avoid glibc symbol version problems.
+FROM ubuntu:14.04
+RUN sudo apt-get update && sudo apt-get -y install ca-certificates build-essential libglib2.0-dev libgtk2.0-dev m4 pkg-config libexpat1-dev unzip gnupg wget --no-install-recommends
+WORKDIR /src
+RUN wget https://www.openssl.org/source/openssl-1.1.1d.tar.gz -O openssl.tgz
+RUN tar xf openssl.tgz
+# Install openssl from source without dynamic libraries. This is the easiest way to force it to be linked statically.
+RUN cd openssl-1.1.1d && ./config no-dgram no-dso no-dynamic-engine no-engine no-shared no-tests && make && sudo make install
+RUN wget https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux -O /usr/local/bin/opam
+RUN chmod a+x /usr/local/bin/opam
+RUN opam init --compiler=4.08.1 --disable-sandboxing
+ENV OPAMYES="1" OPAMERRLOGLEN="0"
+RUN opam install cppo yojson xmlm ounit lwt_react cohttp-lwt-unix lwt_ssl obus lablgtk lwt_glib sha dune
+COPY . /src/
+RUN opam exec -- make
+RUN ldd /src/dist/files/0install
+RUN strip /src/dist/files/0install

--- a/static/Dockerfile-test-debian-10
+++ b/static/Dockerfile-test-debian-10
@@ -1,0 +1,2 @@
+FROM debian:10
+RUN apt-get update && apt-get install -y unzip gpg gpg-agent ca-certificates libgtk2.0 bzip2 python-gobject python2.7 --no-install-recommends

--- a/static/Dockerfile-test-fedora-30
+++ b/static/Dockerfile-test-fedora-30
@@ -1,0 +1,2 @@
+FROM fedora:30
+RUN dnf install -y unzip gpg ca-certificates gtk2 findutils bzip2 python2 pygobject2

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,2 @@
+To build portable static binaries, run `make static/dist.tgz` in the top-level directory.
+This uses Docker. Run `static-test` to test the results.

--- a/static/run-tests.sh
+++ b/static/run-tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu
+cd /tmp
+tar xf /mnt/dist.tgz
+/tmp/dist/install.sh local
+/usr/local/bin/0install --version
+echo -n "Checking that GTK plugin loads... "
+env DISPLAY=:0 0install config -g 2>&1 | grep -q 'ml_gtk_init: initialization failed'
+echo OK
+echo "Checking installation of 0test..."
+0install add 0test http://0install.net/2008/interfaces/0test.xml
+0test --version | grep '0test (zero-install)'
+echo "All tests passed!"


### PR DESCRIPTION
To build portable static binaries, run `make static/dist.tgz` in the top-level directory. This uses Docker. Run `static-test` to test the results. It tests on Debian 10 and Fedora 30 at the moment.