### PR TITLE
Fix use of nested Lwt_main.run

### DIFF
--- a/ocaml/cli/search.ml
+++ b/ocaml/cli/search.ml
@@ -35,7 +35,7 @@ let handle options flags args =
         | `Network_failure msg -> Safe_exn.failf "%s" msg
         | `Tmpfile path ->
             let results = U.read_file config.system path in
-            Lwt_main.run (Lwt_switch.turn_off switch);
+            Lwt_switch.turn_off switch >>= fun () ->
             let root = `String (0, results) |> Xmlm.make_input |> Q.parse_input (Some url) in
 
             Msg.check_tag "results" root;

--- a/ocaml/tests/fake_gpg_agent.ml
+++ b/ocaml/tests/fake_gpg_agent.ml
@@ -69,11 +69,9 @@ let run gpg_dir =
 
 let with_gpg test =
   Fake_system.with_tmpdir (fun tmpdir ->
-    OUnit.skip_if on_windows "No PF_UNIX on Windows";
-    let agent = run tmpdir in
-    Lwt_main.run (
-      Lwt.finalize
-        (fun () -> test tmpdir)
-        (fun () -> Lwt.cancel agent; Lwt.return ())
+      OUnit.skip_if on_windows "No PF_UNIX on Windows";
+      U.finally_do
+        (fun agent -> Lwt.cancel agent)
+        (run tmpdir)
+        (fun _ -> test tmpdir)
     )
-  )

--- a/ocaml/tests/fake_gpg_agent.mli
+++ b/ocaml/tests/fake_gpg_agent.mli
@@ -14,4 +14,4 @@ open Support.Common
 val run : filepath -> unit Lwt.t
 
 (** [with_gpg test] creates a temporary directory with a fake agent socket and runs [test tmpdir] inside it. *)
-val with_gpg : (filepath -> unit Lwt.t) -> (unit -> unit)
+val with_gpg : (filepath -> unit) -> (unit -> unit)

--- a/ocaml/tests/test_0install.ml
+++ b/ocaml/tests/test_0install.ml
@@ -243,8 +243,6 @@ let suite = "0install">::: [
     fake_slave#allow_download "http://foo/Source.xml" new_source_feed;
     let out = run ["update"; "http://foo/Binary.xml"; "--source"] in
     assert_contains "No longer used: http://foo/Compiler.xml" out;
-
-    Lwt.return ()
   );
 
   "download">:: Fake_system.with_tmpdir (fun tmpdir ->
@@ -301,8 +299,7 @@ let suite = "0install">::: [
     fake_slave#allow_download "http://example.com:8000/6FCF121BE2390E0B.gpg" key;
     let out = run ["download"; (Fake_system.test_data "selections.xml"); "--show"] in
     assert_contains digest out;
-    assert_contains "Version: 1\n" out;
-    Lwt.return ()
+    assert_contains "Version: 1\n" out
   );
 
   "display">:: Fake_system.with_tmpdir (fun tmpdir ->
@@ -766,11 +763,10 @@ let suite = "0install">::: [
     assert_contains "FEED" out;
 
     let gpg = Support.Gpg.make config.system in
-    Support.Gpg.import_key gpg (U.read_file config.system (Fake_system.test_data "6FCF121BE2390E0B.gpg")) >>= fun () ->
+    Lwt_main.run @@ Support.Gpg.import_key gpg (U.read_file config.system (Fake_system.test_data "6FCF121BE2390E0B.gpg"));
     let out = run_0install fake_system ~include_stderr:true ["import"; Fake_system.test_data "Hello.xml"] ~stdin:"Y\n" in
     assert_contains "Do you want to trust this key to sign feeds from 'example.com:8000'?" out;
-    Fake_system.fake_log#assert_contains "Trusting DE937DD411906ACF7C263B396FCF121BE2390E0B for example.com:8000";
-    Lwt.return ()
+    Fake_system.fake_log#assert_contains "Trusting DE937DD411906ACF7C263B396FCF121BE2390E0B for example.com:8000"
   );
 
   "list">:: Fake_gpg_agent.with_gpg (fun tmpdir ->
@@ -787,7 +783,7 @@ let suite = "0install">::: [
     assert_str_equal "" out;
 
     let gpg = Support.Gpg.make config.system in
-    Support.Gpg.import_key gpg (U.read_file config.system (Fake_system.test_data "6FCF121BE2390E0B.gpg")) >>= fun () ->
+    Lwt_main.run @@ Support.Gpg.import_key gpg (U.read_file config.system (Fake_system.test_data "6FCF121BE2390E0B.gpg"));
     ignore @@ run_0install fake_system ~include_stderr:true ["import"; Fake_system.test_data "Hello.xml"] ~stdin:"Y\n";
 
     let out = run_0install fake_system ["list"] in
@@ -797,9 +793,7 @@ let suite = "0install">::: [
     assert_str_equal "" out;
 
     let out = run_0install fake_system ["list"; "hello"] in
-    assert_str_equal "http://example.com:8000/Hello.xml\n" out;
-
-    Lwt.return ()
+    assert_str_equal "http://example.com:8000/Hello.xml\n" out
   );
 
   "help">:: Fake_system.with_fake_config (fun (_config, fake_system) ->

--- a/ocaml/tests/test_gpg.ml
+++ b/ocaml/tests/test_gpg.ml
@@ -106,7 +106,7 @@ let with_tal_key test =
   Fake_gpg_agent.with_gpg (fun tmpdir ->
     let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
     let gpg = G.make config.system in
-    G.import_key gpg thomas_key >>= fun () ->
+    Lwt_main.run @@ G.import_key gpg thomas_key;
     test gpg
   )
 
@@ -114,85 +114,97 @@ let suite = "gpg">::: [
   "import-bad">:: Fake_gpg_agent.with_gpg (fun tmpdir ->
     let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
     let gpg = G.make config.system in
-    Lwt.catch
-      (fun () -> G.import_key gpg "Bad key" >>= fun () -> assert false)
-      (function
-        | Safe_exn.T _ -> Lwt.return ()
-        | ex -> Lwt.fail ex
-      )
+    try
+      Lwt_main.run @@ G.import_key gpg "Bad key";
+      assert false
+    with Safe_exn.T _ -> ()
   );
 
   "error-sig">:: Fake_gpg_agent.with_gpg (fun tmpdir ->
     let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
     let gpg = G.make config.system in
-    G.verify gpg err_sig >>= fun (sigs, warnings) ->
-    assert (warnings <> "");
-    match sigs with
-    | [ G.ErrSig (G.UnknownKey "7AB89A977DAAA397") ] -> Lwt.return ()
-    | _ -> assert_failure "Expected ErrSig"
+    Lwt_main.run begin
+      G.verify gpg err_sig >>= fun (sigs, warnings) ->
+      assert (warnings <> "");
+      match sigs with
+      | [ G.ErrSig (G.UnknownKey "7AB89A977DAAA397") ] -> Lwt.return ()
+      | _ -> assert_failure "Expected ErrSig"
+    end
   );
 
   "bad-sig">:: with_tal_key (fun gpg ->
-    G.verify gpg bad_sig >>= fun (sigs, warnings) ->
-    assert (warnings <> "");
-    match sigs with
-    | [ G.BadSig "AE07828059A53CC1" ] -> Lwt.return ()
-    | _ -> assert_failure "Expected BadSig"
+      Lwt_main.run begin
+        G.verify gpg bad_sig >>= fun (sigs, warnings) ->
+        assert (warnings <> "");
+        match sigs with
+        | [ G.BadSig "AE07828059A53CC1" ] -> Lwt.return ()
+        | _ -> assert_failure "Expected BadSig"
+      end
   );
 
   "invalid-sigs">:: Fake_gpg_agent.with_gpg (fun tmpdir ->
     let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
-    let gpg = G.make config.system in
-    invalid_xmls_sigs |> Lwt_list.iter_s (fun (expected, xml) ->
-      let xml = "<?xml version='1.0'?>\n<root/>\n" ^ xml in
-      Lwt.catch
-        (fun () ->
-           G.verify gpg xml >>= fun _ ->
-           assert_failure expected
+    Lwt_main.run begin
+      let gpg = G.make config.system in
+      invalid_xmls_sigs |> Lwt_list.iter_s (fun (expected, xml) ->
+          let xml = "<?xml version='1.0'?>\n<root/>\n" ^ xml in
+          Lwt.catch
+            (fun () ->
+               G.verify gpg xml >>= fun _ ->
+               assert_failure expected
+            )
+            (function
+              | Safe_exn.T e ->
+                let msg = Safe_exn.msg e in
+                Fake_system.assert_str_equal expected msg;
+                Lwt.return ()
+              | ex -> Lwt.fail ex
+            )
         )
-        (function
-          | Safe_exn.T e ->
-            let msg = Safe_exn.msg e in
-            Fake_system.assert_str_equal expected msg;
-            Lwt.return ()
-          | ex -> Lwt.fail ex
-        )
-    )
+    end
   );
 
   "good-sig">:: with_tal_key (fun gpg ->
-    G.verify gpg good_sig >>= fun (sigs, _stderr) ->
-    match sigs with
-    | [ G.ValidSig details ] -> 
-        Fake_system.assert_str_equal "92429807C9853C0744A68B9AAE07828059A53CC1" details.G.fingerprint;
-        G.get_key_name gpg details.G.fingerprint >>= fun name ->
-        Fake_system.assert_str_equal "Thomas Leonard <tal197@users.sourceforge.net>" (Fake_system.expect name);
-        Lwt.return ()
-    | _ -> assert_failure "Expected ValidSig"
+      Lwt_main.run begin
+        G.verify gpg good_sig >>= fun (sigs, _stderr) ->
+        match sigs with
+        | [ G.ValidSig details ] -> 
+          Fake_system.assert_str_equal "92429807C9853C0744A68B9AAE07828059A53CC1" details.G.fingerprint;
+          G.get_key_name gpg details.G.fingerprint >>= fun name ->
+          Fake_system.assert_str_equal "Thomas Leonard <tal197@users.sourceforge.net>" (Fake_system.expect name);
+          Lwt.return ()
+        | _ -> assert_failure "Expected ValidSig"
+      end
   );
 
   "not-xml">:: Fake_gpg_agent.with_gpg (fun tmpdir ->
-    let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
-    let gpg = G.make config.system in
-    Fake_system.assert_raises_safe_lwt "This is not a Zero Install feed! It should be an XML document, but it starts:\nHello"
-      (fun () -> G.verify gpg "Hello" >|= ignore)
-  );
+      Lwt_main.run begin
+        let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
+        let gpg = G.make config.system in
+        Fake_system.assert_raises_safe_lwt "This is not a Zero Install feed! It should be an XML document, but it starts:\nHello"
+          (fun () -> G.verify gpg "Hello" >|= ignore)
+      end
+    );
 
   "no-sigs">:: Fake_gpg_agent.with_gpg (fun tmpdir ->
-    let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
-    let empty_sig = "<?xml version='1.0'?><root/>\n<!-- Base64 Signature\n-->" in
-    let gpg = G.make config.system in
-    G.verify gpg empty_sig >>= fun (sigs, _stderr) ->
-    assert_equal [] sigs;
-    Lwt.return ()
-  );
+      Lwt_main.run begin
+        let (config, _fake_system) = Fake_system.get_fake_config (Some tmpdir) in
+        let empty_sig = "<?xml version='1.0'?><root/>\n<!-- Base64 Signature\n-->" in
+        let gpg = G.make config.system in
+        G.verify gpg empty_sig >>= fun (sigs, _stderr) ->
+        assert_equal [] sigs;
+        Lwt.return ()
+      end
+    );
 
   "load-keys">:: with_tal_key (fun gpg ->
-    G.load_keys gpg [] >>= fun keys ->
-    assert_equal XString.Map.empty keys;
-    G.load_keys gpg [thomas_fingerprint] >>= fun keys ->
-    let info = XString.Map.find_safe thomas_fingerprint keys in
-    Fake_system.assert_str_equal "Thomas Leonard <tal197@users.sourceforge.net>" (Fake_system.expect info.G.name);
-    Lwt.return ()
-  );
+      Lwt_main.run begin
+        G.load_keys gpg [] >>= fun keys ->
+        assert_equal XString.Map.empty keys;
+        G.load_keys gpg [thomas_fingerprint] >>= fun keys ->
+        let info = XString.Map.find_safe thomas_fingerprint keys in
+        Fake_system.assert_str_equal "Thomas Leonard <tal197@users.sourceforge.net>" (Fake_system.expect info.G.name);
+        Lwt.return ()
+      end
+    );
 ]


### PR DESCRIPTION
This is now an error with Lwt 5.0.0.

`0install search` would fail with the error:

    Failure("Nested calls to Lwt_main.run are not allowed")

Some of the unit tests also needed to be fixed.