### PR TITLE
Explicitly depend on pywin32 on Windows

### DIFF
--- a/ZeroInstall.xml
+++ b/ZeroInstall.xml
@@ -45,6 +45,7 @@ interfere with those provided by the distribution.
     </requires>
 
     <requires interface="https://apps.0install.net/python/python.xml" version="3.4.."/>
+    <requires interface="https://apps.0install.net/python/pywin32.xml" os="Windows"/>
 
     <requires interface="http://0install.net/2012/interfaces/0install-runenv-cli.xml" os="Windows">
       <environment insert="runenv.cli.template" mode="replace" name="ZEROINSTALL_CLI_TEMPLATE"/>


### PR DESCRIPTION
Copied from https://github.com/0install/0install-feeds/pull/5 - @bastianeicher I assume we should add this here too?