### PR TITLE
Fix homebrew error

### DIFF
--- a/.travis-extra-deps.sh
+++ b/.travis-extra-deps.sh
@@ -22,9 +22,9 @@ EOF
     sudo hdiutil attach XQuartz-2.7.6.dmg
     sudo installer -verbose -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
     brew update &> /dev/null
-    brew unlink python	# Python 3 conflicts with Python 2's /usr/local/bin/2to3-2 file
+    brew unlink python@2 # Python 3 conflicts with Python 2's /usr/local/bin/2to3-2 file
     brew upgrade gnupg wget
-    brew install gtk+ pygobject
+    brew install gtk+
     export PKG_CONFIG_PATH=/usr/local/Library/Homebrew/os/mac/pkgconfig/10.9:/usr/lib/pkgconfig
   }
 


### PR DESCRIPTION
Error was:

    ==> Pouring python-3.7.6.high_sierra.bottle.tar.gz
    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /usr/local
    Could not symlink Frameworks/Python.framework/Headers
    Target /usr/local/Frameworks/Python.framework/Headers
    is a symlink belonging to python@2. You can unlink it:
      brew unlink python@2

And also:

    pygobject was deleted from homebrew/core in commit fcfa254:
      pygobject: delete
      Does not support Python 3, and needs pygtk which has been removed.

The 0compile branch has now been updated to work with Python 3 and to avoid pygobject. This PR just removes the instruction to install pygobject.