### PR TITLE
Clean up Feed module

### DIFF
--- a/ocaml/cli/add.ml
+++ b/ocaml/cli/add.ml
@@ -19,7 +19,7 @@ let check_for_replacement f config uri =
   match Zeroinstall.Feed_cache.get_cached_feed config feed with
   | None -> log_warning "Master feed for '%s' missing!" uri
   | Some feed ->
-      match feed.F.replacement with
+      match F.replacement feed with
       | Some replacement ->
         Format.fprintf f "Warning: interface %s has been replaced by %s@." uri replacement
       | None -> ()

--- a/ocaml/cli/add_feed.ml
+++ b/ocaml/cli/add_feed.ml
@@ -36,7 +36,7 @@ let edit_feeds_interactive ~stdout config (mode:[`Add | `Remove]) feed_url =
   let feed = FC.get_cached_feed config feed_url |? lazy (failwith "Feed still not cached!") in
   let new_import = F.make_user_import feed_url in
   match F.get_feed_targets feed with
-  | [] -> Element.raise_elem "Missing <feed-for> element; feed can't be used as a feed for any other interface." feed.F.root
+  | [] -> Element.raise_elem "Missing <feed-for> element; feed can't be used as a feed for any other interface." (F.root feed)
   | candidate_interfaces ->
       (* Display the options to the user *)
       let i = ref 0 in

--- a/ocaml/cli/add_feed.ml
+++ b/ocaml/cli/add_feed.ml
@@ -26,7 +26,7 @@ let edit_feeds f config iface mode new_import =
   print "";
   print "Feed list for interface '%s' is now:" iface;
   if extra_feeds <> [] then
-    extra_feeds |> List.iter (fun feed -> print "- %s" (Zeroinstall.Feed_url.format_url feed.F.feed_src))
+    extra_feeds |> List.iter (fun feed -> print "- %s" (Zeroinstall.Feed_url.format_url feed.Feed_import.src))
   else
     print "(no feeds)"
 
@@ -34,7 +34,7 @@ let edit_feeds_interactive ~stdout config (mode:[`Add | `Remove]) feed_url =
   let (`Remote_feed url | `Local_feed url) = feed_url in
   let print f = Format.fprintf stdout (f ^^ "@.") in
   let feed = FC.get_cached_feed config feed_url |? lazy (failwith "Feed still not cached!") in
-  let new_import = F.make_user_import feed_url in
+  let new_import = Feed_import.make_user feed_url in
   match F.get_feed_targets feed with
   | [] -> Element.raise_elem "Missing <feed-for> element; feed can't be used as a feed for any other interface." (F.root feed)
   | candidate_interfaces ->
@@ -119,7 +119,7 @@ let handle options flags args =
   | [iface; feed_src] ->
       let iface = G.canonical_iface_uri config.system iface in
       let feed_src = G.canonical_feed_url config.system feed_src in
-      let new_import = F.make_user_import feed_src in
+      let new_import = Feed_import.make_user feed_src in
 
       let iface_config = FC.load_iface_config config iface in
       if List.mem new_import iface_config.FC.extra_feeds then (

--- a/ocaml/cli/completion.ml
+++ b/ocaml/cli/completion.ml
@@ -289,7 +289,8 @@ let complete_version completer ~range ~maybe_app target pre =
             let v = Zeroinstall.Version.to_string pv in
             let vexpr = v_prefix ^ v in
             if starts_with vexpr pre then Some vexpr else None in
-          let all_versions = List.map (fun impl -> impl.Impl.parsed_version) @@ Feed.get_implementations feed in
+          let all_versions = Feed.zi_implementations feed
+                             |> XString.Map.map_bindings (fun _k impl -> impl.Impl.parsed_version) in
           let matching_versions = Support.Utils.filter_map check (List.sort compare all_versions) in
           List.iter (completer#add Add) matching_versions
 

--- a/ocaml/cli/completion.ml
+++ b/ocaml/cli/completion.ml
@@ -140,7 +140,7 @@ let complete_interfaces_with_feeds config completer pre =
 let complete_extra_feed config completer iface pre =
   let {Feed_cache.extra_feeds; _} = Feed_cache.load_iface_config config iface in
   let add_if_matches feed =
-    let url = feed.Feed.feed_src |> Zeroinstall.Feed_url.format_url in
+    let url = feed.Zeroinstall.Feed_import.src |> Zeroinstall.Feed_url.format_url in
     if starts_with url pre then
       completer#add Add url
   in

--- a/ocaml/cli/list_feeds.ml
+++ b/ocaml/cli/list_feeds.ml
@@ -21,8 +21,8 @@ let handle options flags args =
       begin match iface_config.FC.extra_feeds with
       | [] -> Format.fprintf options.stdout "(no feeds)@."
       | extra_feeds ->
-          extra_feeds |> List.iter (fun {F.feed_src; _} ->
-            Format.fprintf options.stdout "%s@." (Zeroinstall.Feed_url.format_url feed_src);
+          extra_feeds |> List.iter (fun {Zeroinstall.Feed_import.src; _} ->
+            Format.fprintf options.stdout "%s@." (Zeroinstall.Feed_url.format_url src);
           )
       end
   | _ -> raise (Support.Argparse.Usage_error 1)

--- a/ocaml/cli/remove_feed.ml
+++ b/ocaml/cli/remove_feed.ml
@@ -24,7 +24,7 @@ let handle options flags args =
   | [iface; feed_src] ->
       let iface = G.canonical_iface_uri config.system iface in
       let feed_src = G.canonical_feed_url config.system feed_src in
-      let user_import = Zeroinstall.Feed.make_user_import feed_src in
+      let user_import = Zeroinstall.Feed_import.make_user feed_src in
 
       let iface_config = FC.load_iface_config config iface in
       if not (List.mem user_import iface_config.FC.extra_feeds) then (

--- a/ocaml/cli/update.ml
+++ b/ocaml/cli/update.ml
@@ -51,11 +51,11 @@ let get_newest options feed_provider reqs =
 let check_replacement f = function
   | None -> ()
   | Some (feed, _) ->
-      match feed.F.replacement with
+      match F.replacement feed with
       | None -> ()
       | Some replacement ->
-        Format.fprintf f "Warning: interface %s has been replaced by %s@."
-          (Zeroinstall.Feed_url.format_url feed.F.url) replacement
+        Format.fprintf f "Warning: interface %a has been replaced by %s@."
+          Zeroinstall.Feed.pp_url feed replacement
 
 let check_for_updates options reqs old_sels =
   let tools = options.tools in

--- a/ocaml/gui_gtk/add_box.ml
+++ b/ocaml/gui_gtk/add_box.ml
@@ -21,9 +21,9 @@ let xdg_add_to_menu config feed =
     (U.rmtree system ~even_if_locked:true)
     (U.make_tmp_dir system ~prefix:"0desktop-" (Filename.get_temp_dir_name ()))
     (fun tmpdir ->
-      let name = feed.F.name |> String.lowercase_ascii |> Str.global_replace U.re_dir_sep "-" |> Str.global_replace XString.re_space "" in
+      let name = F.name feed |> String.lowercase_ascii |> Str.global_replace U.re_dir_sep "-" |> Str.global_replace XString.re_space "" in
       let desktop_name = tmpdir +/ ("zeroinstall-" ^ name ^ ".desktop") in
-      let icon_path = FC.get_cached_icon_path config feed.F.url in
+      let icon_path = FC.get_cached_icon_path config (F.url feed) in
       desktop_name |> system#with_open_out [Open_wronly; Open_creat] ~mode:0o600 (fun ch ->
         Printf.fprintf ch
           "[Desktop Entry]\n\
@@ -35,9 +35,9 @@ let xdg_add_to_menu config feed =
           Comment=%s\n\
           Exec=0launch -- %s %%f\n\
           Categories=Application;%s\n"
-          feed.F.name
+          (F.name feed)
           (F.get_summary config.langs feed |> default "")
-          (Feed_url.format_url feed.F.url)
+          (Feed_url.format_url (F.url feed))
           (F.get_category feed |> default "");
 
         icon_path |> if_some (Printf.fprintf ch "Icon=%s\n");

--- a/ocaml/gui_gtk/app_list_box.ml
+++ b/ocaml/gui_gtk/app_list_box.ml
@@ -43,7 +43,7 @@ let discover_existing_apps config =
                       let name =
                         try
                           match FC.get_cached_feed config url with
-                          | Some feed -> feed.F.name
+                          | Some feed -> F.name feed
                           | None -> Filename.basename uri
                         with Safe_exn.T _ ->
                           Filename.basename uri in
@@ -144,7 +144,7 @@ let maybe_with_terminal system feed args =
       (* This is probably wrong, or at least inefficient (we ignore [args] and invoke 0launch again).
        * But I don't know how to make the escaping right - someone on OS X should check it... *)
       let osascript = U.find_in_path_ex system "osascript" in
-      let script = "0launch -- " ^ (Feed_url.format_url feed.F.url) in
+      let script = "0launch -- " ^ (Feed_url.format_url (F.url feed)) in
       [osascript; "-e"; "tell app \"Terminal\""; "-e"; "activate"; "-e"; "do script \"" ^ script ^ "\""; "-e"; "end tell"]
     ) else (
       let terminal_args =

--- a/ocaml/gui_gtk/cache_explorer_box.ml
+++ b/ocaml/gui_gtk/cache_explorer_box.ml
@@ -348,7 +348,7 @@ let open_cache_explorer config =
   let impl_of_digest = Hashtbl.create 1024 in
   !ok_feeds |> List.iter (fun feed ->
     (* For each implementation... *)
-    feed.F.implementations |> XString.Map.iter (fun _id impl ->
+    F.zi_implementations feed |> XString.Map.iter (fun _id impl ->
       match impl.Impl.impl_type with
       | `Cache_impl info ->
           (* For each digest... *)
@@ -368,7 +368,7 @@ let open_cache_explorer config =
     Unsorted_list.set model ~row ~column:impl_dir_col @@ dir +/ digest;
     try
       let feed, impl = Hashtbl.find impl_of_digest digest in
-      Unsorted_list.set model ~row ~column:owner_col feed.F.name;
+      Unsorted_list.set model ~row ~column:owner_col @@ F.name feed;
       Unsorted_list.set model ~row ~column:version_str_col @@ Impl.get_attr_ex FeedAttr.version impl;
     with Not_found ->
       try
@@ -412,7 +412,7 @@ let open_cache_explorer config =
               "arch:" ^ Zeroinstall.Arch.format_arch (impl.Impl.os, impl.Impl.machine);
               "langs:" ^ (Impl.get_langs impl |> List.map Support.Locale.format_lang |> String.concat ",");
             ] in
-            (Feed_url.format_url feed.F.url, dir, extra, true, true)
+            (Feed_url.format_url (F.url feed), dir, extra, true, true)
           with Not_found ->
             let extra =
               match config.system#readdir dir with

--- a/ocaml/gui_gtk/component_box.ml
+++ b/ocaml/gui_gtk/component_box.ml
@@ -274,7 +274,7 @@ let make_feeds_tab tools ~trust_db ~recalculate ~watcher window iface =
     | [path] ->
         let iter = feeds_model#get_iter path in
         let feed_import = feeds_model#get ~row:iter ~column:feed_obj in
-        Gui.remove_feed config iface feed_import.F.feed_src;
+        Gui.remove_feed config iface feed_import.Feed_import.src;
         remove_feed#misc#set_sensitive false;
         recalculate ~force:false;
     | _ -> log_warning "Impossible selection!"
@@ -313,8 +313,8 @@ let make_feeds_tab tools ~trust_db ~recalculate ~watcher window iface =
           (* Only enable removing user_override feeds *)
           let iter = feeds_model#get_iter path in
           let feed_import = feeds_model#get ~row:iter ~column:feed_obj in
-          remove_feed#misc#set_sensitive @@ (feed_import.F.feed_type = F.User_registered);
-          begin match watcher#feed_provider#get_feed feed_import.F.feed_src with
+          remove_feed#misc#set_sensitive @@ Feed_import.(feed_import.ty = User_registered);
+          begin match watcher#feed_provider#get_feed feed_import.Feed_import.src with
           | None -> buffer#insert ~iter:buffer#start_iter "Not yet downloaded."; Lwt.return ()
           | Some (feed, overrides) ->
               Gui.generate_feed_description config trust_db feed overrides >|= fun description ->
@@ -354,24 +354,24 @@ let make_feeds_tab tools ~trust_db ~recalculate ~watcher window iface =
         | None -> []
         | Some (feed, _overrides) -> F.imported_feeds feed in
 
-      let main = F.({
-        feed_src = master_feed;
-        feed_os = None;
-        feed_machine = None;
-        feed_langs = None;
-        feed_type = Feed_import;
-      }) in
+      let main = Feed_import.{
+        src = master_feed;
+        os = None;
+        machine = None;
+        langs = None;
+        ty = Feed_import;
+      } in
 
       feeds_model#clear ();
       (main :: (imported_feeds @ extra_feeds)) |> List.iter (fun feed ->
         let row = feeds_model#append () in
         let arch_value =
-          match feed.F.feed_os, feed.F.feed_machine with
+          match Feed_import.(feed.os, feed.machine) with
           | None, None -> ""
           | arch -> Arch.format_arch arch in
-        feeds_model#set ~row ~column:url (Feed_url.format_url feed.F.feed_src);
+        feeds_model#set ~row ~column:url (Feed_url.format_url feed.Feed_import.src);
         feeds_model#set ~row ~column:arch arch_value;
-        feeds_model#set ~row ~column:used (watcher#feed_provider#was_used feed.F.feed_src);
+        feeds_model#set ~row ~column:used (watcher#feed_provider#was_used feed.Feed_import.src);
         feeds_model#set ~row ~column:feed_obj feed;
       );
 

--- a/ocaml/gui_gtk/component_box.ml
+++ b/ocaml/gui_gtk/component_box.ml
@@ -22,9 +22,9 @@ let spf = Printf.sprintf
 let add_description_text ~heading_style ~link_style (buffer:GText.buffer) feed description =
   let open Gui in
   let iter = buffer#start_iter in
-  buffer#insert ~iter ~tags:[heading_style] feed.F.name;
+  buffer#insert ~iter ~tags:[heading_style] (F.name feed);
   buffer#insert ~iter (spf " (%s)" (default "-" @@ description.summary));
-  buffer#insert ~iter (spf "\n%s\n" (Feed_url.format_url feed.F.url));
+  buffer#insert ~iter (spf "\n%s\n" (Feed_url.format_url (F.url feed)));
 
   if description.times <> [] then (
     buffer#insert ~iter "\n";
@@ -52,7 +52,7 @@ let add_description_text ~heading_style ~link_style (buffer:GText.buffer) feed d
     )
   );
 
-  match feed.F.url, description.signatures with
+  match F.url feed, description.signatures with
   | `Local_feed _, _ -> ()
   | `Remote_feed _, [] ->
       buffer#insert ~iter "No signature information (old style feed or out-of-date cache)\n"
@@ -352,7 +352,7 @@ let make_feeds_tab tools ~trust_db ~recalculate ~watcher window iface =
       let imported_feeds =
         match watcher#feed_provider#get_feed master_feed with
         | None -> []
-        | Some (feed, _overrides) -> feed.F.imported_feeds in
+        | Some (feed, _overrides) -> F.imported_feeds feed in
 
       let main = F.({
         feed_src = master_feed;

--- a/ocaml/gui_gtk/component_tree.ml
+++ b/ocaml/gui_gtk/component_tree.ml
@@ -226,9 +226,9 @@ let build_tree_view config ~parent ~packing ~icon_cache ~show_component ~report_
         let master_feed = Feed_url.master_feed_of_iface uri in
         match feed_provider#get_feed master_feed with
         | Some (main_feed, _overrides) ->
-            (main_feed.F.name,
+            (F.name main_feed,
              default "-" @@ F.get_summary config.langs main_feed,
-             main_feed.F.imported_feeds);
+             (F.imported_feeds main_feed))
         | None ->
             let name =
               match master_feed with

--- a/ocaml/gui_gtk/component_tree.ml
+++ b/ocaml/gui_gtk/component_tree.ml
@@ -237,7 +237,7 @@ let build_tree_view config ~parent ~packing ~icon_cache ~show_component ~report_
             (name, "", []) in
 
       let user_feeds = (feed_provider#get_iface_config uri).FC.extra_feeds in
-      let all_feeds = uri :: (user_feeds @ feed_imports |> List.map (fun {F.feed_src; _} -> Feed_url.format_url feed_src)) in
+      let all_feeds = uri :: (user_feeds @ feed_imports |> List.map (fun {Feed_import.src; _} -> Feed_url.format_url src)) in
 
       (* This is the set of feeds corresponding to this interface. It's used to correlate downloads with components.
        * Note: "distribution:" feeds give their master feed as their hint, so are not included here. *)

--- a/ocaml/gui_gtk/component_tree.ml
+++ b/ocaml/gui_gtk/component_tree.ml
@@ -254,9 +254,8 @@ let build_tree_view config ~parent ~packing ~icon_cache ~show_component ~report_
       match details with
       | `Selected (impl, children) ->
           let {Feed_url.id; feed = from_feed} = Impl.get_id impl in
-          let overrides = Feed.load_feed_overrides config from_feed in
-          let user_stability = XString.Map.find_opt id overrides.Feed.user_stability in
-
+          let overrides = Feed_metadata.load config from_feed in
+          let user_stability = Feed_metadata.stability id overrides in
           let version = impl.Impl.parsed_version |> Version.to_string in
           let stability_str =
             match user_stability with

--- a/ocaml/tests/test_0install.ml
+++ b/ocaml/tests/test_0install.ml
@@ -54,7 +54,7 @@ let impl_from_json config = (function
   | `Assoc [("id", `String id); ("from-feed", `String feed_url)] ->
       let parsed = Zeroinstall.Feed_url.parse_non_distro feed_url in
       let feed = Zeroinstall.Feed_cache.get_cached_feed config parsed |? lazy (Safe_exn.failf "Not cached: %s" feed_url) in
-      XString.Map.find_safe id feed.F.implementations
+      XString.Map.find_safe id (F.zi_implementations feed)
   | _ -> assert false
 )
 

--- a/ocaml/tests/test_distro.ml
+++ b/ocaml/tests/test_distro.ml
@@ -380,7 +380,7 @@ let suite = "distro">::: [
         inherit Zeroinstall.Feed_provider_impl.feed_provider config deb
         method! get_feed = function
           | (`Remote_feed "http://example.com/bittorrent") as url ->
-              let result = Some (feed, F.({ last_checked = None; user_stability = XString.Map.empty })) in
+              let result = Some (feed, Feed_metadata.{ last_checked = None; user_stability = XString.Map.empty }) in
               cache <- Zeroinstall.Feed_url.FeedMap.add url result cache;
               result
           | _ -> assert false

--- a/ocaml/tests/test_distro.ml
+++ b/ocaml/tests/test_distro.ml
@@ -267,7 +267,7 @@ let suite = "distro">::: [
       match host_gobject.props.requires with
       | [ {dep_importance = `Restricts; dep_iface = "http://repo.roscidus.com/python/python"; dep_restrictions = [_]; _ } ] -> ()
       | _ -> assert_failure "No host restriction for host python-gobject" in
-    let from_feed = Zeroinstall.Feed_url.format_url (`Distribution_feed feed.F.url) in
+    let from_feed = Zeroinstall.Feed_url.format_url (`Distribution_feed (F.url feed)) in
     let attrs = host_gobject.props.attrs
       |> Q.AttrMap.add_no_ns "from-feed" from_feed in
     let sel = ZI.make "selection" ~attrs in
@@ -348,7 +348,7 @@ let suite = "distro">::: [
 
     let feed = F.parse config.system root (Some "/local.xml") in
 
-    assert_equal 0 (XString.Map.cardinal feed.F.implementations);
+    assert_equal 0 (XString.Map.cardinal (F.zi_implementations feed));
 
     let dpkgdir = Fake_system.test_data "dpkg" in
     let old_path = Unix.getenv "PATH" in

--- a/ocaml/tests/test_download.ml
+++ b/ocaml/tests/test_download.ml
@@ -274,7 +274,7 @@ let suite = "download">::: [
 
     (* Check we imported the interface after trusting the key *)
     let hello = FC.get_cached_feed config (`Remote_feed "http://localhost:8000/Hello") |> Fake_system.expect in
-    assert_equal 1 @@ XString.Map.cardinal hello.F.implementations;
+    assert_equal 1 @@ XString.Map.cardinal (F.zi_implementations hello);
 
     (* Shouldn't need to prompt the second time *)
     let out = run_0install fake_system ~stdin:"" ["import"; Fake_system.test_data "Hello"] in
@@ -299,7 +299,7 @@ let suite = "download">::: [
     ));
 
     let feed = Fake_system.expect @@ FC.get_cached_feed config (`Remote_feed native_url) in
-    assert_equal 0 @@ XString.Map.cardinal feed.F.implementations;
+    assert_equal 0 @@ XString.Map.cardinal (F.zi_implementations feed);
 
     let dpkgdir = Fake_system.test_data "dpkg" in
     let old_path = Unix.getenv "PATH" in

--- a/ocaml/tests/test_download.ml
+++ b/ocaml/tests/test_download.ml
@@ -771,7 +771,7 @@ let suite = "download">::: [
 
     (* Check background select - update metadata only *)
     let url = "http://example.com:8000/Hello.xml" in
-    F.save_feed_overrides config (`Remote_feed url) F.({last_checked = None; user_stability = XString.Map.empty});
+    Feed_metadata.save config (`Remote_feed url) {Feed_metadata.last_checked = None; user_stability = XString.Map.empty};
     let rel_path = config_site +/ config_prog +/ "last-check-attempt" +/ Zeroinstall.Escape.pretty url in
     let basedirs = Support.Basedir.get_default_config config.system in
     let last_check_attempt = B.load_first config.system rel_path basedirs.B.cache |> expect in

--- a/ocaml/tests/test_feed.ml
+++ b/ocaml/tests/test_feed.ml
@@ -120,7 +120,7 @@ let suite = "feed">::: [
     | _ -> assert false end;
 
     begin match F.imported_feeds feed with
-    | [subfeed] -> assert_equal (Some ["fr"; "en_GB"]) subfeed.F.feed_langs
+    | [subfeed] -> assert_equal (Some ["fr"; "en_GB"]) subfeed.Feed_import.langs
     | _ -> assert false end;
   );
 

--- a/ocaml/tests/test_feed.ml
+++ b/ocaml/tests/test_feed.ml
@@ -57,20 +57,20 @@ let suite = "feed">::: [
     let feed_url = Fake_system.test_data "Hello.xml" in
     let digest = "sha1=3ce644dc725f1d21cfcf02562c76f375944b266a" in
 
-    let overrides = F.load_feed_overrides config (`Local_feed feed_url) in
-    assert_equal None overrides.F.last_checked;
-    assert_equal 0 (XString.Map.cardinal overrides.F.user_stability);
+    let overrides = Feed_metadata.load config (`Local_feed feed_url) in
+    assert_equal None overrides.Feed_metadata.last_checked;
+    assert_equal 0 (XString.Map.cardinal overrides.Feed_metadata.user_stability);
 
-    F.save_feed_overrides config (`Local_feed feed_url) {
-      F.user_stability = XString.Map.add digest Stability.Developer overrides.F.user_stability;
-      F.last_checked = Some 100.0;
+    Feed_metadata.save config (`Local_feed feed_url) { Feed_metadata.
+      user_stability = XString.Map.add digest Stability.Developer overrides.Feed_metadata.user_stability;
+      last_checked = Some 100.0;
     };
 
     (* Rating now visible *)
-    let overrides = F.load_feed_overrides config (`Local_feed feed_url) in
-    assert_equal 1 (XString.Map.cardinal overrides.F.user_stability);
-    assert_equal Stability.Developer (XString.Map.find_safe digest overrides.F.user_stability);
-    assert_equal (Some 100.0) overrides.F.last_checked;
+    let overrides = Feed_metadata.load config (`Local_feed feed_url) in
+    assert_equal 1 (XString.Map.cardinal overrides.Feed_metadata.user_stability);
+    assert_equal Stability.Developer (XString.Map.find_safe digest overrides.Feed_metadata.user_stability);
+    assert_equal (Some 100.0) overrides.Feed_metadata.last_checked;
   );
 
   "command">:: Fake_system.with_fake_config (fun (config, _fake_system) ->

--- a/ocaml/tests/test_feed.ml
+++ b/ocaml/tests/test_feed.ml
@@ -82,15 +82,15 @@ let suite = "feed">::: [
       let command = XString.Map.find_safe name impl.Impl.props.Impl.commands in
       Element.path command.Impl.command_qdom |> Fake_system.expect in
 
-    let a = XString.Map.find_safe "a" feed.F.implementations in
+    let a = XString.Map.find_safe "a" (F.zi_implementations feed) in
     Fake_system.assert_str_equal "foo" @@ path "run" a;
     Fake_system.assert_str_equal "test-foo" @@ path "test" a;
 
-    let b = XString.Map.find_safe "b" feed.F.implementations in
+    let b = XString.Map.find_safe "b" (F.zi_implementations feed) in
     Fake_system.assert_str_equal "bar" @@ path "run" b;
     Fake_system.assert_str_equal "test-foo" @@ path "test" b;
 
-    let c = XString.Map.find_safe "c" feed.F.implementations in
+    let c = XString.Map.find_safe "c" (F.zi_implementations feed) in
     Fake_system.assert_str_equal "test-gui" @@ path "run" c;
     Fake_system.assert_str_equal "test-baz" @@ path "test" c;
   );
@@ -112,14 +112,14 @@ let suite = "feed">::: [
       </interface>" in
     let root = `String (0, xml) |> Xmlm.make_input |> Q.parse_input None |> Element.parse_feed in
     let feed = F.parse config.system root (Some "/local.xml") in
-    begin match XString.Map.bindings feed.F.implementations with
+    begin match XString.Map.bindings (F.zi_implementations feed) with
     | [("sha1=124", s124); ("sha1=234", s234); ("sha1=345", s345)] ->
         assert_equal [("fr", None)] @@ Impl.get_langs s124;
         assert_equal [("fr", None); ("en", Some "gb")] @@ Impl.get_langs s234;
         assert_equal [("en", None)] @@ Impl.get_langs s345;
     | _ -> assert false end;
 
-    begin match feed.F.imported_feeds with
+    begin match F.imported_feeds feed with
     | [subfeed] -> assert_equal (Some ["fr"; "en_GB"]) subfeed.F.feed_langs
     | _ -> assert false end;
   );
@@ -147,7 +147,7 @@ let suite = "feed">::: [
     let root = `String (0, xml) |> Xmlm.make_input |> Q.parse_input None |> Element.parse_feed in
     let feed = F.parse config.system root (Some "/local.xml") in
 
-    begin match XString.Map.bindings feed.F.implementations with
+    begin match XString.Map.bindings (F.zi_implementations feed) with
     | [("sha1=123", impl)] ->
         begin match impl.Impl.props.Impl.bindings |> List.map Element.classify_binding |> List.map B.parse_binding with
         | [B.EnvironmentBinding {B.mode = B.Replace; _}] -> ()
@@ -234,7 +234,7 @@ let suite = "feed">::: [
         </group>\n\
       </interface>" in
 
-    match feed.F.implementations |> XString.Map.bindings with
+    match F.zi_implementations feed |> XString.Map.bindings with
     | [("sha1=123", impl)] ->
         begin match impl.Impl.props.Impl.requires with
         | [dep; dep2] ->
@@ -263,7 +263,7 @@ let suite = "feed">::: [
         <implementation id='used' version='2' if-0install-version='1..'/>\n\
       </interface>" in
 
-    match feed.F.implementations |> XString.Map.bindings with
+    match F.zi_implementations feed |> XString.Map.bindings with
     | [("sha1=123", impl); ("used", used)] ->
         Fake_system.assert_str_equal "1.0-rc3-pre" @@ Zeroinstall.Version.to_string impl.Impl.parsed_version;
         Fake_system.assert_str_equal "2" @@ Zeroinstall.Version.to_string used.Impl.parsed_version;
@@ -285,7 +285,7 @@ let suite = "feed">::: [
         </group>\n\
       </interface>" in
 
-    match feed.F.implementations |> XString.Map.bindings with
+    match F.zi_implementations feed |> XString.Map.bindings with
     | [("sha1=123", impl1); ("sha1=124", impl2)] ->
         let check expected name impl =
           let attr = Q.AttrMap.get name impl.Impl.props.Impl.attrs |> default "" in
@@ -345,6 +345,6 @@ let suite = "feed">::: [
     let iface = Fake_system.test_data "Replaced.xml" in
     let root = Q.parse_file system iface |> Element.parse_feed in
     let feed = F.parse system root (Some iface) in
-    Fake_system.assert_str_equal "http://localhost:8000/Hello" (Fake_system.expect feed.F.replacement)
+    Fake_system.assert_str_equal "http://localhost:8000/Hello" (Fake_system.expect (F.replacement feed))
   );
 ]

--- a/ocaml/tests/test_feed_cache.ml
+++ b/ocaml/tests/test_feed_cache.ml
@@ -32,7 +32,7 @@ let suite = "feed-cache">::: [
 
     assert (Feed_cache.is_stale never url);         (* Stale because no last checked time *)
     fake_system#set_time 100.0;
-    Feed.update_last_checked_time config url;
+    Feed_metadata.update_last_checked_time config url;
     fake_system#set_time 200.0;
 
     assert (Feed_cache.is_stale one_second url);

--- a/ocaml/tests/test_feed_cache.ml
+++ b/ocaml/tests/test_feed_cache.ml
@@ -136,9 +136,9 @@ let suite = "feed-cache">::: [
 
     Feed_cache.save_iface_config config iface {
       Feed_cache.stability_policy = Some Stability.Developer;
-      Feed_cache.extra_feeds = [
-        { F.feed_src = `Remote_feed "http://sys-feed"; F.feed_os = None; F.feed_machine = None; F.feed_langs = None; F.feed_type = F.Distro_packages };
-        { F.feed_src = `Remote_feed "http://user-feed"; F.feed_os = Some Arch.linux; F.feed_machine = None; F.feed_langs = None; F.feed_type = F.User_registered };
+      Feed_cache.extra_feeds = Feed_import.[
+        { src = `Remote_feed "http://sys-feed"; os = None; machine = None; langs = None; ty = Distro_packages };
+        { src = `Remote_feed "http://user-feed"; os = Some Arch.linux; machine = None; langs = None; ty = User_registered };
       ];
     };
 
@@ -146,7 +146,7 @@ let suite = "feed-cache">::: [
     let iface_config = Feed_cache.load_iface_config config iface in
     assert_equal (Some Stability.Developer) iface_config.Feed_cache.stability_policy;
     begin match iface_config.Feed_cache.extra_feeds with
-    | [ {F.feed_src = `Remote_feed "http://user-feed"; F.feed_os; F.feed_machine = None; _ } ] when feed_os = Some Arch.linux -> ()
+    | [ {Feed_import.src = `Remote_feed "http://user-feed"; os; machine = None; _ } ] when os = Some Arch.linux -> ()
     | _ -> assert false end;
   );
 
@@ -182,7 +182,7 @@ let suite = "feed-cache">::: [
     let iface = "http://example.com/section/prog_1.xml" in
     let iface_config = Feed_cache.load_iface_config config iface in
     begin match iface_config.Feed_cache.extra_feeds with
-    | [ {F.feed_type = F.Site_packages; _} ] -> ()
+    | [ Feed_import.{ty = Site_packages; _} ] -> ()
     | _ -> assert false end;
 
     (* Check that we write it out, so that older 0installs can find it *)

--- a/ocaml/tests/test_fetch.ml
+++ b/ocaml/tests/test_fetch.ml
@@ -184,7 +184,7 @@ let suite = "fetch">::: [
 
     let check ?error ?testfile id =
       try
-        let impl = XString.Map.find_safe id feed.F.implementations in
+        let impl = XString.Map.find_safe id (F.zi_implementations feed) in
         let digests =
           match impl.Impl.impl_type with
           | `Cache_impl {Impl.digests; _} -> digests

--- a/ocaml/tests/test_selections.ml
+++ b/ocaml/tests/test_selections.ml
@@ -38,7 +38,7 @@ let suite = "selections">::: [
     let import name =
       let url = `Remote_feed ("http://foo/" ^ name) in
       U.copy_file config.system (Fake_system.test_data name) (Test_driver.cache_path_for config url) 0o644;
-      Zeroinstall.Feed.update_last_checked_time config url in
+      Zeroinstall.Feed_metadata.update_last_checked_time config url in
     import "Source.xml";
     import "Compiler.xml";
     fake_system#set_argv [| Test_0install.test_0install; "select"; "--xml";  "--command=compile"; "--source"; "http://foo/Source.xml" |];

--- a/ocaml/tests/test_solver.ml
+++ b/ocaml/tests/test_solver.ml
@@ -114,9 +114,9 @@ class fake_feed_provider system (distro:Distro.provider option) =
   object (_ : #Feed_provider.feed_provider)
     method get_feed url =
       try
-        let overrides = {
-          Feed.last_checked = None;
-          Feed.user_stability = XString.Map.empty;
+        let overrides = { Feed_metadata.
+          last_checked = None;
+          user_stability = XString.Map.empty;
         } in
         Some (Hashtbl.find ifaces url, overrides)
       with Not_found -> None
@@ -125,9 +125,9 @@ class fake_feed_provider system (distro:Distro.provider option) =
       Hashtbl.add ifaces url feed
 
     method get_distro_impls feed =
-      let overrides = {
-        Feed.last_checked = None;
-        Feed.user_stability = XString.Map.empty;
+      let overrides = { Feed_metadata.
+        last_checked = None;
+        user_stability = XString.Map.empty;
       } in
       match distro with
       | None -> {Feed_provider.impls = XString.Map.empty; overrides; problems = []}
@@ -432,12 +432,14 @@ let suite = "solver">::: [
           match super#get_feed url with
           | None -> None
           | Some (feed, overrides) ->
-              let overrides = {overrides with Feed.user_stability = XString.Map.singleton "preferred_by_user" Stability.Preferred} in
+              let overrides = {
+                overrides with Feed_metadata.user_stability = XString.Map.singleton "preferred_by_user" Stability.Preferred
+              } in
               Some (feed, overrides)
 
         method! get_distro_impls feed =
           let result = super#get_distro_impls feed in
-          let overrides = {result.Feed_provider.overrides with Feed.user_stability = XString.Map.singleton "package:buggy" Stability.Buggy} in
+          let overrides = {result.Feed_provider.overrides with Feed_metadata.user_stability = XString.Map.singleton "package:buggy" Stability.Buggy} in
           {result with Feed_provider.overrides}
       end in
     feed_provider#add_iface (Support.Qdom.parse_file Fake_system.real_system (Fake_system.test_data "ranking.xml"));

--- a/ocaml/tests/test_solver.ml
+++ b/ocaml/tests/test_solver.ml
@@ -361,8 +361,8 @@ let suite = "solver">::: [
     let iface_config = feed_provider#get_iface_config uri in
     assert (iface_config.stability_policy = None);
     match iface_config.extra_feeds with
-    | [ { Feed.feed_src = `Local_feed "/usr/share/0install.net/native_feeds/http:##example.com#prog";
-          Feed.feed_type = Feed.Distro_packages; _ } ] -> ()
+    | [ Feed_import.{ src = `Local_feed "/usr/share/0install.net/native_feeds/http:##example.com#prog";
+                      ty = Distro_packages; _ } ] -> ()
     | _ -> assert_failure "Didn't find native feed"
   );
 

--- a/ocaml/zeroinstall/distro.ml
+++ b/ocaml/zeroinstall/distro.ml
@@ -16,7 +16,7 @@ module Q = Support.Qdom
 let get_matching_package_impls distro feed =
   let best_score = ref 0 in
   let best_impls = ref [] in
-  feed.Feed.package_implementations |> List.iter (function (elem, _) as package_impl ->
+  Feed.package_implementations feed |> List.iter (function (elem, _) as package_impl ->
     let package_name = Element.package elem in
     if distro#is_valid_package_name package_name then (
         let distributions = default "" @@ Element.distributions elem in
@@ -217,7 +217,7 @@ class virtual distribution config =
       let results = ref XString.Map.empty in
 
       if check_host_python then (
-        Host_python.get host_python feed.Feed.url |> List.iter (fun (id, impl) -> results := XString.Map.add id impl !results)
+        Host_python.get host_python (Feed.url feed) |> List.iter (fun (id, impl) -> results := XString.Map.add id impl !results)
       );
 
       match get_matching_package_impls self feed with

--- a/ocaml/zeroinstall/distro.ml
+++ b/ocaml/zeroinstall/distro.ml
@@ -41,7 +41,7 @@ module Query = struct
     elem : [`Package_impl] Element.t; (* The <package-element> which generated this query *)
     package_name : string;            (* The 'package' attribute on the <package-element> *)
     elem_props : Impl.properties;     (* Properties on or inherited by the <package-element> - used by [add_package_implementation] *)
-    feed : Feed.feed;                 (* The feed containing the <package-element> *)
+    feed : Feed.t;                    (* The feed containing the <package-element> *)
     results : Impl.distro_implementation Support.XString.Map.t ref;
     problem : string -> unit;
     version_ok : Version.version_expr;
@@ -100,9 +100,9 @@ class type virtual provider =
     method is_installed : Selections.selection -> bool
     method get_impls_for_feed :
       problem:(string -> unit) ->
-      Feed.feed ->
+      Feed.t ->
       Impl.distro_implementation Support.XString.Map.t
-    method virtual check_for_candidates : 'a. ui:(#Packagekit.ui as 'a) -> Feed.feed -> unit Lwt.t
+    method virtual check_for_candidates : 'a. ui:(#Packagekit.ui as 'a) -> Feed.t -> unit Lwt.t
     method install_distro_packages : 'a. (#Packagekit.ui as 'a) -> string -> (Impl.distro_implementation * Impl.distro_retrieval_method) list -> [ `Ok | `Cancel ] Lwt.t
     method is_valid_package_name : string -> bool
   end
@@ -213,7 +213,7 @@ class virtual distribution config =
 
     (** Get the native implementations (installed or candidates for installation) for this feed.
      * This default implementation finds the best <package-implementation> elements and calls [get_package_impls] on each one. *)
-    method get_impls_for_feed ~problem (feed:Feed.feed) : Impl.distro_implementation XString.Map.t =
+    method get_impls_for_feed ~problem (feed:Feed.t) : Impl.distro_implementation XString.Map.t =
       let results = ref XString.Map.empty in
 
       if check_host_python then (

--- a/ocaml/zeroinstall/distro.mli
+++ b/ocaml/zeroinstall/distro.mli
@@ -40,12 +40,12 @@ class type virtual provider =
      * @param problem called to add warnings or notes about problems, for diagnostics *)
     method get_impls_for_feed :
       problem:(string -> unit) ->
-      Feed.feed ->
+      Feed.t ->
       Impl.distro_implementation Support.XString.Map.t
 
     (** Check (asynchronously) for available but currently uninstalled candidates. Once the returned
         promise resolves, the candidates should be included in future responses from [get_package_impls]. *)
-    method virtual check_for_candidates : 'a. ui:(#Packagekit.ui as 'a) -> Feed.feed -> unit Lwt.t
+    method virtual check_for_candidates : 'a. ui:(#Packagekit.ui as 'a) -> Feed.t -> unit Lwt.t
 
     (** Install a set of packages of a given type (as set previously by [check_for_candidates]).
      * Normally called only by the [Distro.install_distro_packages] function.
@@ -109,7 +109,7 @@ class virtual distribution : General.config ->
   end
 
 (** Return the <package-implementation> elements that best match this distribution. *)
-val get_matching_package_impls : #distribution -> Feed.feed -> ([`Package_impl] Element.t * Impl.properties) list
+val get_matching_package_impls : #distribution -> Feed.t -> ([`Package_impl] Element.t * Impl.properties) list
 
 (** {2 API for users of the distribution abstraction.} *)
 
@@ -122,12 +122,12 @@ val of_provider : #provider -> t
     @param problem called to add warnings or notes about problems, for diagnostics *)
 val get_impls_for_feed : t -> 
   problem:(string -> unit) ->
-  Feed.feed ->
+  Feed.t ->
   Impl.distro_implementation Support.XString.Map.t
 
 (** Check (asynchronously) for available but currently uninstalled candidates. Once the returned
     promise resolves, the candidates will be included in future responses from [get_impls_for_feed]. *)
-val check_for_candidates : t -> ui:#Packagekit.ui -> Feed.feed -> unit Lwt.t
+val check_for_candidates : t -> ui:#Packagekit.ui -> Feed.t -> unit Lwt.t
 
 (** Install these packages using the distribution's package manager. *)
 val install_distro_packages : t -> #Packagekit.ui -> Impl.distro_implementation list -> [ `Ok | `Cancel ] Lwt.t

--- a/ocaml/zeroinstall/distro_impls.ml
+++ b/ocaml/zeroinstall/distro_impls.ml
@@ -60,7 +60,7 @@ class virtual packagekit_distro ~(packagekit:Packagekit.packagekit Lazy.t) confi
           | `Unavailable _ -> Lwt.return ()
           | `Ok ->
               let package_names = matches |> List.map (fun (elem, _props) -> Element.package elem) in
-              let hint = Feed_url.format_url feed.Feed.url in
+              let hint = Feed_url.format_url (Feed.url feed) in
               packagekit#check_for_candidates ~ui ~hint package_names
 
     method! install_distro_packages ui typ items =
@@ -344,7 +344,7 @@ module Debian = struct
         match Distro.get_matching_package_impls self feed with
         | [] -> Lwt.return ()
         | matches ->
-            let hint = Feed_url.format_url feed.Feed.url in
+            let hint = Feed_url.format_url (Feed.url feed) in
             let packagekit = Lazy.force packagekit in
             let package_names = matches |> List.map (fun (elem, _props) -> Element.package elem) in
             (* Check apt-cache to see whether we have the pacakges. If PackageKit isn't available, we'll use these

--- a/ocaml/zeroinstall/driver.ml
+++ b/ocaml/zeroinstall/driver.ml
@@ -48,7 +48,7 @@ let find_distro_impl feed_provider id master_feed =
 (** Find a cached implementation. Not_found if the feed isn't cached or doesn't contain [id]. *)
 let find_zi_impl feed_provider id url =
   let (feed, _) = feed_provider#get_feed url |? lazy (raise Not_found) in
-  XString.Map.find id feed.Feed.implementations
+  XString.Map.find id (Feed.zi_implementations feed)
 
 module DownloadElt =
   struct

--- a/ocaml/zeroinstall/feed.ml
+++ b/ocaml/zeroinstall/feed.ml
@@ -33,7 +33,7 @@ type feed_import = {
   feed_type: feed_type;
 }
 
-type feed = {
+type t = {
   url : Feed_url.non_distro_feed;
   root : [`Feed] Element.t;
   name : string;

--- a/ocaml/zeroinstall/feed.ml
+++ b/ocaml/zeroinstall/feed.ml
@@ -276,10 +276,6 @@ let parse system root feed_local_path =
     imported_feeds = !imported_feeds;
   }
 
-(* Get all the implementations (note: only sorted by ID) *)
-let get_implementations feed =
-  XString.Map.map_bindings (fun _k impl -> impl) feed.implementations
-
 (** Load per-feed extra data (last-checked time and preferred stability.
     Probably we should use a simple timestamp file for the last-checked time and attach
     the stability ratings to the interface, not the feed. *)
@@ -363,3 +359,11 @@ let icons feed =
 
 let get_summary langs feed = Element.get_summary langs feed.root
 let get_description langs feed = Element.get_description langs feed.root
+let url t = t.url
+let zi_implementations t = t.implementations
+let package_implementations t = t.package_implementations
+let replacement t = t.replacement
+let imported_feeds t = t.imported_feeds
+let name t = t.name
+let pp_url f t = Feed_url.pp f t.url
+let root t = t.root

--- a/ocaml/zeroinstall/feed.mli
+++ b/ocaml/zeroinstall/feed.mli
@@ -29,7 +29,7 @@ type feed_import = {
   feed_type : feed_type;
 }
 
-type feed = {
+type t = {
   url : Feed_url.non_distro_feed;
   root : [`Feed] Element.t;
   name : string;
@@ -44,22 +44,22 @@ type feed = {
 }
 
 (** {2 Parsing} *)
-val parse : #filesystem -> [`Feed] Element.t -> filepath option -> feed
+val parse : #filesystem -> [`Feed] Element.t -> filepath option -> t
 
-val get_implementations : feed -> Impl.existing Impl.t list
+val get_implementations : t -> Impl.existing Impl.t list
 val default_attrs : url:string -> Support.Qdom.AttrMap.t
 val process_group_properties : local_dir:filepath option -> Impl.properties ->
   [<`Group | `Implementation | `Package_impl] Element.t -> Impl.properties
 val load_feed_overrides : General.config -> [< Feed_url.parsed_feed_url] -> feed_overrides
 val save_feed_overrides : General.config -> [< Feed_url.parsed_feed_url] -> feed_overrides -> unit
 val update_last_checked_time : General.config -> [< Feed_url.remote_feed] -> unit
-val get_summary : int Support.Locale.LangMap.t -> feed -> string option
-val get_description : int Support.Locale.LangMap.t -> feed -> string option
+val get_summary : int Support.Locale.LangMap.t -> t -> string option
+val get_description : int Support.Locale.LangMap.t -> t -> string option
 
 (** The <feed-for> elements' interfaces *)
-val get_feed_targets : feed -> Sigs.iface_uri list
+val get_feed_targets : t -> Sigs.iface_uri list
 val make_user_import : [< Feed_url.non_distro_feed] -> feed_import
 
-val get_category : feed -> string option
-val needs_terminal : feed -> bool
-val icons : feed -> [`Icon] Element.t list
+val get_category : t -> string option
+val needs_terminal : t -> bool
+val icons : t -> [`Icon] Element.t list

--- a/ocaml/zeroinstall/feed.mli
+++ b/ocaml/zeroinstall/feed.mli
@@ -7,25 +7,13 @@
 open Support
 open Support.Common
 
-(** {2 Types} **)
-
-type feed_overrides = {
-  last_checked : float option;
-  user_stability : Stability.t XString.Map.t;
-}
-
 type t
 
-(** {2 Parsing} *)
 val parse : #filesystem -> [`Feed] Element.t -> filepath option -> t
 
 val default_attrs : url:string -> Support.Qdom.AttrMap.t
 val process_group_properties : local_dir:filepath option -> Impl.properties ->
   [<`Group | `Implementation | `Package_impl] Element.t -> Impl.properties
-
-val load_feed_overrides : General.config -> [< Feed_url.parsed_feed_url] -> feed_overrides
-val save_feed_overrides : General.config -> [< Feed_url.parsed_feed_url] -> feed_overrides -> unit
-val update_last_checked_time : General.config -> [< Feed_url.remote_feed] -> unit
 
 val url : t -> Feed_url.non_distro_feed
 val name : t -> string

--- a/ocaml/zeroinstall/feed.mli
+++ b/ocaml/zeroinstall/feed.mli
@@ -14,21 +14,6 @@ type feed_overrides = {
   user_stability : Stability.t XString.Map.t;
 }
 
-type feed_type =
-  | Feed_import             (* A <feed> import element inside a feed *)
-  | User_registered         (* Added manually with "0install add-feed" : save to config *)
-  | Site_packages           (* Found in the site-packages directory : save to config for older versions, but flag it *)
-  | Distro_packages         (* Found in native_feeds : don't save *)
-
-type feed_import = {
-  feed_src : Feed_url.non_distro_feed;
-
-  feed_os : Arch.os option;           (* All impls requires this OS *)
-  feed_machine : Arch.machine option; (* All impls requires this CPU *)
-  feed_langs : string list option;    (* No impls for languages not listed *)
-  feed_type : feed_type;
-}
-
 type t
 
 (** {2 Parsing} *)
@@ -46,13 +31,12 @@ val url : t -> Feed_url.non_distro_feed
 val name : t -> string
 val get_summary : int Support.Locale.LangMap.t -> t -> string option
 val get_description : int Support.Locale.LangMap.t -> t -> string option
-val imported_feeds : t -> feed_import list
+val imported_feeds : t -> Feed_import.t list
 val zi_implementations : t -> [> `Cache_impl of Impl.cache_impl | `Local_impl of filepath] Impl.t XString.Map.t
 val package_implementations : t -> ([`Package_impl] Element.t * Impl.properties) list
 
 (** The <feed-for> elements' interfaces *)
 val get_feed_targets : t -> Sigs.iface_uri list
-val make_user_import : [< Feed_url.non_distro_feed] -> feed_import
 
 val get_category : t -> string option
 val needs_terminal : t -> bool

--- a/ocaml/zeroinstall/feed.mli
+++ b/ocaml/zeroinstall/feed.mli
@@ -29,32 +29,26 @@ type feed_import = {
   feed_type : feed_type;
 }
 
-type t = {
-  url : Feed_url.non_distro_feed;
-  root : [`Feed] Element.t;
-  name : string;
-  implementations : 'a. ([> `Cache_impl of Impl.cache_impl | `Local_impl of filepath] as 'a) Impl.t XString.Map.t;
-  imported_feeds : feed_import list;    (* Always of type Feed_import here *)
-
-  (* The URI of the interface that replaced the one with the URI of this feed's URL.
-     This is the value of the feed's <replaced-by interface'...'/> element. *)
-  replacement : Sigs.iface_uri option;
-
-  package_implementations : ([`Package_impl] Element.t * Impl.properties) list;
-}
+type t
 
 (** {2 Parsing} *)
 val parse : #filesystem -> [`Feed] Element.t -> filepath option -> t
 
-val get_implementations : t -> Impl.existing Impl.t list
 val default_attrs : url:string -> Support.Qdom.AttrMap.t
 val process_group_properties : local_dir:filepath option -> Impl.properties ->
   [<`Group | `Implementation | `Package_impl] Element.t -> Impl.properties
+
 val load_feed_overrides : General.config -> [< Feed_url.parsed_feed_url] -> feed_overrides
 val save_feed_overrides : General.config -> [< Feed_url.parsed_feed_url] -> feed_overrides -> unit
 val update_last_checked_time : General.config -> [< Feed_url.remote_feed] -> unit
+
+val url : t -> Feed_url.non_distro_feed
+val name : t -> string
 val get_summary : int Support.Locale.LangMap.t -> t -> string option
 val get_description : int Support.Locale.LangMap.t -> t -> string option
+val imported_feeds : t -> feed_import list
+val zi_implementations : t -> [> `Cache_impl of Impl.cache_impl | `Local_impl of filepath] Impl.t XString.Map.t
+val package_implementations : t -> ([`Package_impl] Element.t * Impl.properties) list
 
 (** The <feed-for> elements' interfaces *)
 val get_feed_targets : t -> Sigs.iface_uri list
@@ -63,3 +57,10 @@ val make_user_import : [< Feed_url.non_distro_feed] -> feed_import
 val get_category : t -> string option
 val needs_terminal : t -> bool
 val icons : t -> [`Icon] Element.t list
+
+val replacement : t -> Sigs.iface_uri option
+(** The URI of the interface that replaced the one with the URI of this feed's URL.
+    This is the value of the feed's <replaced-by interface'...'/> element. *)
+
+val root : t -> [`Feed] Element.t
+val pp_url : Format.formatter -> t -> unit

--- a/ocaml/zeroinstall/feed_cache.ml
+++ b/ocaml/zeroinstall/feed_cache.ml
@@ -181,8 +181,8 @@ let get_cached_feed config = function
       | Some path ->
           let root = Q.parse_file config.system path |> Element.parse_feed in
           let feed = Feed.parse config.system root None in
-          if feed.Feed.url = remote_feed then Some feed
-          else Safe_exn.failf "Incorrect URL in cached feed - expected '%s' but found '%s'" url (Feed_url.format_url feed.Feed.url)
+          if Feed.url feed = remote_feed then Some feed
+          else Safe_exn.failf "Incorrect URL in cached feed - expected '%s' but found '%a'" url Feed.pp_url feed
 
 let get_last_check_attempt config url =
   match Paths.Cache.(first (last_check_attempt url)) config.paths with

--- a/ocaml/zeroinstall/feed_cache.ml
+++ b/ocaml/zeroinstall/feed_cache.ml
@@ -204,7 +204,7 @@ let internal_is_stale config (`Remote_feed url as feed_url) overrides =
   match overrides with
   | None -> is_stale ()
   | Some overrides ->
-      match overrides.Feed.last_checked with
+      match overrides.Feed_metadata.last_checked with
       | None ->
           log_debug "Feed '%s' has no last checked time, so needs update" url;
           is_stale ()
@@ -218,7 +218,7 @@ let internal_is_stale config (`Remote_feed url as feed_url) overrides =
           | _ -> false
 
 let is_stale config url =
-  let overrides = Feed.load_feed_overrides config url in
+  let overrides = Feed_metadata.load config url in
   internal_is_stale config url (Some overrides)
 
 let mark_as_checking config url =

--- a/ocaml/zeroinstall/feed_cache.mli
+++ b/ocaml/zeroinstall/feed_cache.mli
@@ -15,7 +15,7 @@ type interface_config = {
 
 (** Load a cached feed.
  * As a convenience, this will also load local feeds. *)
-val get_cached_feed : config -> [< Feed_url.non_distro_feed] -> Feed.feed option
+val get_cached_feed : config -> [< Feed_url.non_distro_feed] -> Feed.t option
 val get_cached_feed_path : config -> Feed_url.remote_feed -> filepath option
 val get_save_cache_path : config -> Feed_url.remote_feed -> filepath
 

--- a/ocaml/zeroinstall/feed_cache.mli
+++ b/ocaml/zeroinstall/feed_cache.mli
@@ -32,7 +32,7 @@ val is_stale : config -> Feed_url.remote_feed -> bool
 
 (** Low-level part of [is_stale] that doesn't automatically load the feed overrides (needed to get [last_checked]).
  * Useful if you've already loaded them yourself (or confirmed they're missing) to avoid doing it twice. *)
-val internal_is_stale : config -> Feed_url.remote_feed -> Feed.feed_overrides option -> bool
+val internal_is_stale : config -> Feed_url.remote_feed -> Feed_metadata.t option -> bool
 
 (** Touch a 'last-check-attempt' timestamp file for this feed.
     This prevents us from repeatedly trying to download a failing feed many

--- a/ocaml/zeroinstall/feed_cache.mli
+++ b/ocaml/zeroinstall/feed_cache.mli
@@ -10,7 +10,7 @@ open Support.Common
 
 type interface_config = {
   stability_policy : Stability.t option;      (* Overrides config.help_with_testing if set *)
-  extra_feeds : Feed.feed_import list;        (* Feeds added manually with "0install add-feed" *)
+  extra_feeds : Feed_import.t list;           (* Feeds added manually with "0install add-feed" *)
 }
 
 (** Load a cached feed.

--- a/ocaml/zeroinstall/feed_import.ml
+++ b/ocaml/zeroinstall/feed_import.ml
@@ -1,0 +1,24 @@
+(* Copyright (C) 2020, Thomas Leonard
+   See the README file for details, or visit http://0install.net. *)
+
+type feed_type =
+  | Feed_import             (* A <feed> import element inside a feed *)
+  | User_registered         (* Added manually with "0install add-feed" : save to config *)
+  | Site_packages           (* Found in the site-packages directory : save to config for older versions, but flag it *)
+  | Distro_packages         (* Found in native_feeds : don't save *)
+
+type t = {
+  src : Feed_url.non_distro_feed;
+  os : Arch.os option;           (* All impls requires this OS *)
+  machine : Arch.machine option; (* All impls requires this CPU *)
+  langs : string list option;    (* No impls for languages not listed *)
+  ty : feed_type;
+}
+
+let make_user src = {
+  src = (src :> Feed_url.non_distro_feed);
+  os = None;
+  machine = None;
+  langs = None;
+  ty = User_registered;
+}

--- a/ocaml/zeroinstall/feed_import.mli
+++ b/ocaml/zeroinstall/feed_import.mli
@@ -1,0 +1,21 @@
+(* Copyright (C) 2020, Thomas Leonard
+   See the README file for details, or visit http://0install.net. *)
+
+(** Parsed feed imports. *)
+
+type feed_type =
+  | Feed_import             (* A <feed> import element inside a feed *)
+  | User_registered         (* Added manually with "0install add-feed" : save to config *)
+  | Site_packages           (* Found in the site-packages directory : save to config for older versions, but flag it *)
+  | Distro_packages         (* Found in native_feeds : don't save *)
+
+type t = {
+  src : Feed_url.non_distro_feed;
+
+  os : Arch.os option;           (* All impls requires this OS *)
+  machine : Arch.machine option; (* All impls requires this CPU *)
+  langs : string list option;    (* No impls for languages not listed *)
+  ty : feed_type;
+}
+
+val make_user : [< Feed_url.non_distro_feed] -> t

--- a/ocaml/zeroinstall/feed_metadata.ml
+++ b/ocaml/zeroinstall/feed_metadata.ml
@@ -1,0 +1,63 @@
+(* Copyright (C) 2020, Thomas Leonard
+   See the README file for details, or visit http://0install.net. *)
+
+open Support
+open General
+
+(* Probably we should use a simple timestamp file for the last-checked
+   time and attach the stability ratings to the interface, not the feed. *)
+type t = {
+  last_checked : float option;
+  user_stability : Stability.t XString.Map.t;
+}
+
+let load config feed_url =
+  match Paths.Config.(first (feed feed_url)) config.paths with
+  | None -> { last_checked = None; user_stability = XString.Map.empty }
+  | Some path ->
+      let root = Qdom.parse_file config.system path in
+      let last_checked =
+        match ZI.get_attribute_opt "last-checked" root with
+        | None -> None
+        | Some time -> Some (float_of_string time)
+      in
+      let stability = ref XString.Map.empty in
+      root |> ZI.iter ~name:"implementation" (fun impl ->
+        let id = ZI.get_attribute "id" impl in
+        match ZI.get_attribute_opt Constants.FeedConfigAttr.user_stability impl with
+        | None -> ()
+        | Some s -> stability := XString.Map.add id (Stability.of_string ~from_user:true s) !stability
+      );
+      { last_checked; user_stability = !stability; }
+
+let save config feed_url {last_checked; user_stability} =
+  let feed_path = Paths.Config.(save_path (feed feed_url)) config.paths in
+  let attrs =
+    match last_checked with
+    | None -> Qdom.AttrMap.empty
+    | Some last_checked -> Qdom.AttrMap.singleton "last-checked" (Printf.sprintf "%.0f" last_checked) in
+  let child_nodes = user_stability |> XString.Map.map_bindings (fun id stability ->
+    ZI.make "implementation" ~attrs:(
+      Qdom.AttrMap.singleton Constants.FeedAttr.id id
+      |> Qdom.AttrMap.add_no_ns Constants.FeedConfigAttr.user_stability (Stability.to_string stability)
+    )
+  ) in
+  let root = ZI.make ~attrs ~child_nodes "feed-preferences" in
+  feed_path |> config.system#atomic_write [Open_wronly; Open_binary] ~mode:0o644 (fun ch ->
+    Qdom.output (`Channel ch |> Xmlm.make_output) root;
+  )
+
+let update config url f =
+  load config url |> f |> save config url
+
+let update_last_checked_time config url =
+  update config url (fun t -> {t with last_checked = Some config.system#time})
+
+let stability id t = XString.Map.find_opt id t.user_stability
+
+let with_stability id rating t =
+  { t with user_stability =
+      match rating with
+      | None -> XString.Map.remove id t.user_stability
+      | Some rating -> XString.Map.add id rating t.user_stability
+  }

--- a/ocaml/zeroinstall/feed_metadata.mli
+++ b/ocaml/zeroinstall/feed_metadata.mli
@@ -1,0 +1,27 @@
+(* Copyright (C) 2020, Thomas Leonard
+   See the README file for details, or visit http://0install.net. *)
+
+(** Mutable state associated with feeds. *)
+
+open Support
+
+type t = {
+  last_checked : float option;
+  user_stability : Stability.t XString.Map.t;
+}
+
+val load : General.config -> [< Feed_url.parsed_feed_url] -> t
+(** Load per-feed extra data (last-checked time and preferred stability). *)
+
+val save : General.config -> [< Feed_url.parsed_feed_url] -> t -> unit
+
+val update : General.config -> [< Feed_url.parsed_feed_url] -> (t -> t) -> unit
+(** [update config url f] loads the metadata for [url], transforms it with [f], and then saves it back. *)
+
+val update_last_checked_time : General.config -> [< Feed_url.remote_feed] -> unit
+
+val stability : string -> t -> Stability.t option 
+(** [stability id t] is the user's rating of [id], if any. *)
+
+val with_stability : string -> Stability.t option -> t -> t
+(** [with_stability id rating t] is [t] with [id]'s user stability set to [rating]. *)

--- a/ocaml/zeroinstall/feed_provider.mli
+++ b/ocaml/zeroinstall/feed_provider.mli
@@ -8,7 +8,7 @@ open Support
 
 type distro_impls = {
   impls : Impl.distro_implementation XString.Map.t;
-  overrides : Feed.feed_overrides;
+  overrides : Feed_metadata.t;
   problems : string list;
 }
 
@@ -17,7 +17,7 @@ class type feed_provider =
     method forget_distro : Feed_url.non_distro_feed -> unit
     method forget_user_feeds : Sigs.iface_uri -> unit
     method get_distro_impls : Feed.t -> distro_impls
-    method get_feed : Feed_url.non_distro_feed -> (Feed.t * Feed.feed_overrides) option
+    method get_feed : Feed_url.non_distro_feed -> (Feed.t * Feed_metadata.t) option
     method get_feeds_used : Feed_url.non_distro_feed list
     method get_iface_config : Sigs.iface_uri -> Feed_cache.interface_config
     method have_stale_feeds : bool

--- a/ocaml/zeroinstall/feed_provider.mli
+++ b/ocaml/zeroinstall/feed_provider.mli
@@ -16,11 +16,11 @@ class type feed_provider =
   object
     method forget_distro : Feed_url.non_distro_feed -> unit
     method forget_user_feeds : Sigs.iface_uri -> unit
-    method get_distro_impls : Feed.feed -> distro_impls
-    method get_feed : Feed_url.non_distro_feed -> (Feed.feed * Feed.feed_overrides) option
+    method get_distro_impls : Feed.t -> distro_impls
+    method get_feed : Feed_url.non_distro_feed -> (Feed.t * Feed.feed_overrides) option
     method get_feeds_used : Feed_url.non_distro_feed list
     method get_iface_config : Sigs.iface_uri -> Feed_cache.interface_config
     method have_stale_feeds : bool
-    method replace_feed : Feed_url.non_distro_feed -> Feed.feed -> unit
+    method replace_feed : Feed_url.non_distro_feed -> Feed.t -> unit
     method was_used : Feed_url.non_distro_feed -> bool
   end

--- a/ocaml/zeroinstall/feed_provider_impl.ml
+++ b/ocaml/zeroinstall/feed_provider_impl.ml
@@ -15,7 +15,7 @@ class feed_provider config distro =
     val mutable cache = FeedMap.empty
     val mutable distro_cache : Feed_provider.distro_impls FeedMap.t = FeedMap.empty
 
-    method get_feed url : (Feed.feed * Feed.feed_overrides) option =
+    method get_feed url : (Feed.t * Feed.feed_overrides) option =
       try FeedMap.find url cache
       with Not_found ->
         let result =

--- a/ocaml/zeroinstall/feed_provider_impl.ml
+++ b/ocaml/zeroinstall/feed_provider_impl.ml
@@ -15,13 +15,13 @@ class feed_provider config distro =
     val mutable cache = FeedMap.empty
     val mutable distro_cache : Feed_provider.distro_impls FeedMap.t = FeedMap.empty
 
-    method get_feed url : (Feed.t * Feed.feed_overrides) option =
+    method get_feed url : (Feed.t * Feed_metadata.t) option =
       try FeedMap.find url cache
       with Not_found ->
         let result =
           match Feed_cache.get_cached_feed config url with
           | Some feed ->
-            let overrides = Feed.load_feed_overrides config url in
+            let overrides = Feed_metadata.load config url in
             Some (feed, overrides)
           | None -> None in
         cache <- FeedMap.add url result cache;
@@ -36,7 +36,7 @@ class feed_provider config distro =
         let problem msg = problems := msg :: !problems in
         let result =
           let impls = Distro.get_impls_for_feed distro ~problem feed in
-          let overrides = Feed.load_feed_overrides config url in
+          let overrides = Feed_metadata.load config url in
           {Feed_provider.impls; overrides; problems = !problems} in
         distro_cache <- FeedMap.add master_feed_url result distro_cache;
         result
@@ -59,7 +59,7 @@ class feed_provider config distro =
       FeedMap.exists check cache
 
     method replace_feed url new_feed =
-      let overrides = Feed.load_feed_overrides config url in
+      let overrides = Feed_metadata.load config url in
       cache <- FeedMap.add url (Some (new_feed, overrides)) cache
 
     method forget_distro url = distro_cache <- FeedMap.remove url distro_cache

--- a/ocaml/zeroinstall/feed_provider_impl.ml
+++ b/ocaml/zeroinstall/feed_provider_impl.ml
@@ -67,7 +67,7 @@ class feed_provider config distro =
     (* Used after compiling a new version. *)
     method forget_user_feeds iface =
       let iface_config = self#get_iface_config iface in
-      iface_config.Feed_cache.extra_feeds |> List.iter (fun {Feed.feed_src; _} ->
-        cache <- FeedMap.remove feed_src cache
+      iface_config.Feed_cache.extra_feeds |> List.iter (fun {Feed_import.src; _} ->
+        cache <- FeedMap.remove src cache
       )
   end

--- a/ocaml/zeroinstall/feed_provider_impl.ml
+++ b/ocaml/zeroinstall/feed_provider_impl.ml
@@ -28,7 +28,7 @@ class feed_provider config distro =
         result
 
     method get_distro_impls feed =
-      let master_feed_url = feed.Feed.url in
+      let master_feed_url = Feed.url feed in
       let url = `Distribution_feed master_feed_url in
       try FeedMap.find master_feed_url distro_cache
       with Not_found ->

--- a/ocaml/zeroinstall/feed_url.ml
+++ b/ocaml/zeroinstall/feed_url.ml
@@ -32,6 +32,8 @@ let format_url = function
   | `Distribution_feed master -> "distribution:" ^ (format_non_distro master)
   | #non_distro_feed as x -> format_non_distro x
 
+let pp f x = Format.pp_print_string f (format_url x)
+
 let master_feed_of_iface uri = parse_non_distro uri
 
 module FeedElt =

--- a/ocaml/zeroinstall/feed_url.mli
+++ b/ocaml/zeroinstall/feed_url.mli
@@ -21,6 +21,8 @@ val parse : Sigs.feed_url -> parsed_feed_url
 
 val format_url : [< parsed_feed_url] -> Sigs.feed_url
 
+val pp : Format.formatter -> [< parsed_feed_url] -> unit
+
 (** Get the master feed for an interface URI. Internally, this is just [parse_non_distro]. *)
 val master_feed_of_iface : Sigs.iface_uri -> [> non_distro_feed]
 

--- a/ocaml/zeroinstall/fetch.ml
+++ b/ocaml/zeroinstall/fetch.ml
@@ -207,7 +207,7 @@ class fetcher config (trust_db:Trust.trust_db) distro (download_pool:Downloader.
 
     let success () =
       if not config.dry_run then (
-        Feed.update_last_checked_time config feed;
+        Feed_metadata.update_last_checked_time config feed;
         log_info "Updated feed cache checked time for %s (modified %s)" feed_url pretty_time
       );
       `Ok new_root |> Lwt.return in

--- a/ocaml/zeroinstall/fetch.ml
+++ b/ocaml/zeroinstall/fetch.ml
@@ -192,7 +192,7 @@ class fetcher config (trust_db:Trust.trust_db) distro (download_pool:Downloader.
 
     (* Check the new XML is valid before adding it *)
     let new_root = `String (0, new_xml) |> Xmlm.make_input |> Q.parse_input (Some feed_url) |> Element.parse_feed in
-    ignore (Feed.parse system new_root None).Feed.root;
+    ignore (Feed.parse system new_root None);
 
     let url_in_feed = Element.uri_exn new_root in
     if url_in_feed <> feed_url then

--- a/ocaml/zeroinstall/gui.ml
+++ b/ocaml/zeroinstall/gui.ml
@@ -76,7 +76,7 @@ let have_source_for feed_provider iface =
   let imported =
     match feed_provider#get_feed master_feed with
     | None -> []
-    | Some (feed, _overrides) -> feed.Feed.imported_feeds in
+    | Some (feed, _overrides) -> Feed.imported_feeds feed in
 
   let have_source = ref false in
   let to_check = ref [master_feed] in
@@ -101,7 +101,7 @@ let have_source_for feed_provider iface =
       match feed_provider#get_feed url with
       | None -> false
       | Some (feed, _overrides) ->
-          feed.Feed.implementations |> XString.Map.exists (fun _id impl -> Impl.is_source impl)
+        Feed.zi_implementations feed |> XString.Map.exists (fun _id impl -> Impl.is_source impl)
     )
   )
 
@@ -401,7 +401,7 @@ let format_para para =
 let generate_feed_description config trust_db feed overrides =
   let times = ref [] in
 
-  begin match feed.F.url with
+  begin match F.url feed with
   | `Local_feed _ -> Lwt.return []
   | `Remote_feed _ as feed_url ->
       let domain = Trust.domain_from_url feed_url in
@@ -441,7 +441,7 @@ let generate_feed_description config trust_db feed overrides =
     | Some description -> Str.split (Str.regexp_string "\n\n") description |> List.map format_para
     | None -> ["-"] in
 
-  let homepages = Element.feed_metadata feed.F.root |> U.filter_map (function
+  let homepages = Feed.root feed |> Element.feed_metadata |> U.filter_map (function
     | `Homepage homepage -> Some (Element.simple_content homepage)
     | _ -> None
   ) in

--- a/ocaml/zeroinstall/gui.ml
+++ b/ocaml/zeroinstall/gui.ml
@@ -82,10 +82,10 @@ let have_source_for feed_provider iface =
   let to_check = ref [master_feed] in
 
   (user_feeds @ imported) |> List.iter (fun feed_import ->
-    match feed_import.Feed.feed_machine with
+    match feed_import.Feed_import.machine with
     | x when Arch.is_src x -> have_source := true   (* Source-only feed *)
     | Some _ -> ()    (* Binary-only feed; can't contain source *)
-    | None -> to_check := feed_import.Feed.feed_src :: !to_check (* Mixed *)
+    | None -> to_check := feed_import.Feed_import.src :: !to_check (* Mixed *)
   );
 
   if !have_source then true
@@ -151,7 +151,7 @@ let add_feed config iface feed_url =
   match Feed.get_feed_targets feed with
   | [] -> Safe_exn.failf "Feed '%s' is not a feed for '%s'" url iface
   | feed_for when List.mem iface feed_for ->
-      let user_import = Feed.make_user_import feed_url in
+      let user_import = Feed_import.make_user feed_url in
       let iface_config = Feed_cache.load_iface_config config iface in
 
       let extra_feeds = iface_config.Feed_cache.extra_feeds in
@@ -170,7 +170,7 @@ let add_remote_feed config fetcher iface (feed_url:[`Remote_feed of Sigs.feed_ur
 
 let remove_feed config iface feed_url =
   let iface_config = Feed_cache.load_iface_config config iface in
-  let user_import = Feed.make_user_import feed_url in
+  let user_import = Feed_import.make_user feed_url in
   let extra_feeds = iface_config.Feed_cache.extra_feeds |> List.filter ((<>) user_import) in
   if iface_config.Feed_cache.extra_feeds = extra_feeds then (
     Safe_exn.failf "Can't remove '%s'; it is not a user-added feed of %s" (Feed_url.format_url feed_url) iface;

--- a/ocaml/zeroinstall/gui.ml
+++ b/ocaml/zeroinstall/gui.ml
@@ -178,16 +178,6 @@ let remove_feed config iface feed_url =
     Feed_cache.save_iface_config config iface {iface_config with Feed_cache.extra_feeds};
   )
 
-let set_impl_stability config {Feed_url.feed; Feed_url.id} rating =
-  let overrides = Feed.load_feed_overrides config feed in
-  let overrides = {
-    overrides with F.user_stability =
-      match rating with
-      | None -> XString.Map.remove id overrides.F.user_stability
-      | Some rating -> XString.Map.add id rating overrides.F.user_stability
-  } in
-  F.save_feed_overrides config feed overrides
-
 (** Run [argv] and return its stdout on success.
  * On error, report both stdout and stderr. *)
 let run_subprocess argv =
@@ -412,12 +402,12 @@ let generate_feed_description config trust_db feed overrides =
         | None -> ()
       );
 
-      overrides.F.last_checked |> if_some (fun last_checked ->
+      overrides.Feed_metadata.last_checked |> if_some (fun last_checked ->
         times := ("Last checked", last_checked) :: !times
       );
 
       Feed_cache.get_last_check_attempt config feed_url |> if_some (fun last_check_attempt ->
-        match overrides.F.last_checked with
+        match overrides.Feed_metadata.last_checked with
         | Some last_checked when last_check_attempt <= last_checked ->
             () (* Don't bother reporting successful attempts *)
         | _ ->

--- a/ocaml/zeroinstall/gui.mli
+++ b/ocaml/zeroinstall/gui.mli
@@ -57,9 +57,6 @@ val list_impls : Solver.Model.t -> Solver.role ->
 (* Returns (fetch-size, fetch-tooltip) *)
 val get_fetch_info : General.config -> Impl.generic_implementation -> (string * string)
 
-(** Set a user-override stability rating. *)
-val set_impl_stability : General.config -> Feed_url.global_id -> Stability.t option -> unit
-
 (** Get the initial text for the bug report dialog box. *)
 val get_bug_report_details : General.config -> role:Solver.role -> (bool * Solver.Model.t) -> string
 
@@ -70,4 +67,4 @@ val send_bug_report : Sigs.iface_uri -> string -> string Lwt.t
 
 val run_test : General.config -> Distro.t -> (Selections.t -> string Lwt.t) -> (bool * Solver.Model.t) -> string Lwt.t
 
-val generate_feed_description : General.config -> Trust.trust_db -> Feed.t -> Feed.feed_overrides -> feed_description Lwt.t
+val generate_feed_description : General.config -> Trust.trust_db -> Feed.t -> Feed_metadata.t -> feed_description Lwt.t

--- a/ocaml/zeroinstall/gui.mli
+++ b/ocaml/zeroinstall/gui.mli
@@ -70,4 +70,4 @@ val send_bug_report : Sigs.iface_uri -> string -> string Lwt.t
 
 val run_test : General.config -> Distro.t -> (Selections.t -> string Lwt.t) -> (bool * Solver.Model.t) -> string Lwt.t
 
-val generate_feed_description : General.config -> Trust.trust_db -> Feed.feed -> Feed.feed_overrides -> feed_description Lwt.t
+val generate_feed_description : General.config -> Trust.trust_db -> Feed.t -> Feed.feed_overrides -> feed_description Lwt.t

--- a/ocaml/zeroinstall/impl_provider.ml
+++ b/ocaml/zeroinstall/impl_provider.ml
@@ -257,16 +257,16 @@ class default_impl_provider config (feed_provider : Feed_provider.feed_provider)
       (* Don't look at a feed if it only provides things we can't use. *)
       if Scope_filter.use_feed scope_filter ~want_source feed_import
       then (
-        let feed = feed_provider#get_feed feed_import.Feed.feed_src in
+        let feed = feed_provider#get_feed feed_import.Feed_import.src in
         if feed = None then (
-          let feed_url = Feed_url.format_url feed_import.Feed.feed_src in
+          let feed_url = Feed_url.format_url feed_import.Feed_import.src in
           problem (Printf.sprintf "Imported feed '%s' not available" feed_url)
         );
         feed
       ) else None
     with Safe_exn.T _ as ex ->
       log_warning ~ex "Failed to get implementations";
-      let feed_url = Feed_url.format_url feed_import.Feed.feed_src in
+      let feed_url = Feed_url.format_url feed_import.Feed_import.src in
       problem (Printf.sprintf "Error getting imported feed '%s': %s" feed_url (Printexc.to_string ex));
       None
   in

--- a/ocaml/zeroinstall/impl_provider.ml
+++ b/ocaml/zeroinstall/impl_provider.ml
@@ -236,7 +236,7 @@ class default_impl_provider config (feed_provider : Feed_provider.feed_provider)
 
   let get_impls ~problem (feed, overrides) =
     let distro_impls = (get_distro_impls ~problem feed :> Impl.existing Impl.t list) in
-    let zi_impls = (do_overrides overrides feed.Feed.implementations :> Impl.existing Impl.t list) in
+    let zi_impls = do_overrides overrides (Feed.zi_implementations feed) in
     distro_impls @ zi_impls in
 
   let cached_digests = Stores.get_available_digests config.system config.stores in
@@ -288,7 +288,7 @@ class default_impl_provider config (feed_provider : Feed_provider.feed_provider)
           problem (Printf.sprintf "Main feed '%s' not available" iface);
           ([], None)
       | Some ((feed, _overrides) as pair) ->
-          let sub_feeds = U.filter_map (get_feed_if_useful ~problem want_source) feed.Feed.imported_feeds in
+          let sub_feeds = U.filter_map (get_feed_if_useful ~problem want_source) (Feed.imported_feeds feed) in
           let impls = List.concat (List.map (get_impls ~problem) (pair :: sub_feeds)) in
           (impls, iface_config.Feed_cache.stability_policy) in
 
@@ -304,7 +304,7 @@ class default_impl_provider config (feed_provider : Feed_provider.feed_provider)
     let replacement =
       match master_feed with
       | None -> None
-      | Some (feed, _overrides) -> feed.Feed.replacement in
+      | Some (feed, _overrides) -> Feed.replacement feed in
 
     let user_restrictions = Scope_filter.user_restriction_for scope_filter iface in
 

--- a/ocaml/zeroinstall/impl_provider.ml
+++ b/ocaml/zeroinstall/impl_provider.ml
@@ -85,7 +85,7 @@ class type impl_provider =
 (** Convert a map of impls to a list, applying any overrides to the stability fields. *)
 let do_overrides overrides =
   XString.Map.map_bindings (fun id impl ->
-    match XString.Map.find_opt id overrides.Feed.user_stability with
+    match XString.Map.find_opt id overrides.Feed_metadata.user_stability with
     | Some stability -> Impl.with_stability stability impl
     | None -> impl
   )

--- a/ocaml/zeroinstall/scope_filter.ml
+++ b/ocaml/zeroinstall/scope_filter.ml
@@ -38,9 +38,9 @@ let user_restriction_for t iface = XString.Map.find_opt iface t.extra_restrictio
 
 let use_feed t ~want_source feed =
   let machine_ok =
-    match feed.Feed.feed_machine with
+    match feed.Feed_import.machine with
     | None -> true    (* Feed doesn't say what it contains, so we can't safely skip it *)
     | m when Arch.is_src m -> want_source || t.may_compile (* Feed contains only source *)
     | Some _ when want_source -> false      (* Feed contains only binaries and we want source *)
     | Some _ as m -> Arch.machine_ok t.machine_ranks m in
-  machine_ok && Arch.os_ok t.os_ranks feed.Feed.feed_os
+  machine_ok && Arch.os_ok t.os_ranks feed.Feed_import.os

--- a/ocaml/zeroinstall/scope_filter.mli
+++ b/ocaml/zeroinstall/scope_filter.mli
@@ -42,4 +42,4 @@ val lang_rank : t -> Support.Locale.lang_spec -> int
 val user_restriction_for : t -> Sigs.iface_uri -> Impl.restriction option
 
 (* Should we consider this feed import? *)
-val use_feed : t -> want_source:bool -> Feed.feed_import -> bool
+val use_feed : t -> want_source:bool -> Feed_import.t -> bool


### PR DESCRIPTION
- Rename `Feed.feed` to `Feed.t`
- Make `Feed.t` abstract
- Split `Feed_import` out into its own module
- Split `Feed_metadata` out into its own module