### PR TITLE
Make the solver return a SOLVER_RESULT

### DIFF
--- a/ocaml/cli/update.ml
+++ b/ocaml/cli/update.ml
@@ -23,7 +23,7 @@ let get_newest options feed_provider reqs =
   let module Solver = Zeroinstall.Solver in
   let impl_provider =
     let make_impl_provider scope_filter = new I.default_impl_provider options.config feed_provider scope_filter in
-    let root_role = Solver.((get_root_requirements options.config reqs make_impl_provider).Model.role) in
+    let root_role = Solver.((get_root_requirements options.config reqs make_impl_provider).Input.role) in
     Solver.impl_provider root_role in
 
   let get_impls = impl_provider#get_implementations reqs.R.interface_uri in

--- a/ocaml/gui_gtk/component_box.ml
+++ b/ocaml/gui_gtk/component_box.ml
@@ -608,7 +608,7 @@ let make_versions_tab config reqs ~recalculate ~watcher window role =
 
 let create tools ~trust_db reqs role ~recalculate ~select_versions_tab ~watcher =
   let config = tools#config in
-  let title = Format.asprintf "Properties for %a" Solver.Model.Role.pp role in
+  let title = Format.asprintf "Properties for %a" Solver.Input.Role.pp role in
   let dialog = GWindow.dialog ~title () in
   dialog#set_default_size
     ~width:(-1)

--- a/ocaml/gui_gtk/component_tree.ml
+++ b/ocaml/gui_gtk/component_tree.ml
@@ -62,7 +62,7 @@ let walk_tree (model:GTree.tree_store) ~start ~stop fn =
   try walk ~start
   with Stop_walk -> ()
 
-module SolverTree = Tree.Make(Solver.Model)
+module SolverTree = Tree.Make(Solver.Output)
 
 let build_tree_view config ~parent ~packing ~icon_cache ~show_component ~report_bug ~recalculate ~watcher =
   (* Model *)
@@ -252,7 +252,8 @@ let build_tree_view config ~parent ~packing ~icon_cache ~show_component ~report_
       model#set ~row ~column:icon (icon_cache#get ~update ~feed_provider uri |> default default_icon);
 
       match details with
-      | `Selected (impl, children) ->
+      | `Selected (sel, children) ->
+          let impl = Solver.Output.unwrap sel in
           let {Feed_url.id; feed = from_feed} = Impl.get_id impl in
           let overrides = Feed_metadata.load config from_feed in
           let user_stability = Feed_metadata.stability id overrides in

--- a/ocaml/gui_gtk/solver_box.ml
+++ b/ocaml/gui_gtk/solver_box.ml
@@ -14,7 +14,7 @@ module Requirements = Zeroinstall.Requirements
 module U = Support.Utils
 module Progress = Zeroinstall.Progress
 module Downloader = Zeroinstall.Downloader
-module RoleMap = Zeroinstall.Solver.Model.RoleMap
+module RoleMap = Zeroinstall.Solver.Output.RoleMap
 
 let main_window_help = Help_box.create "0install Help" [
 ("Overview",
@@ -360,7 +360,7 @@ let run_solver ~show_preferences ~trust_db tools ?test_callback ?(systray=false)
       widgets.ok_button#misc#set_sensitive ready;
 
       let new_roles =
-        Zeroinstall.Solver.Model.raw_selections results
+        Zeroinstall.Solver.Output.to_map results
         |> RoleMap.mapi (fun new_role _impl -> new_role) in
 
       !component_boxes |> RoleMap.iter (fun old_role box ->

--- a/ocaml/solver/zeroinstall_solver.mli
+++ b/ocaml/solver/zeroinstall_solver.mli
@@ -6,29 +6,17 @@ module S = S
 (** Select a compatible set of components to run a program.
     See [Zeroinstall.Solver] for the instantiation of this functor on the
     actual 0install types. *)
-module Make(Model : S.SOLVER_INPUT) : sig
-  type diagnostics
-
-  type selection = {
-    impl : Model.impl;                  (** The implementation chosen to fill the role *)
-    commands : Model.command_name list; (** The commands required *)
-    diagnostics : diagnostics;          (** Extra information useful for diagnostics *)
-  }
-
-  module RoleMap : Map.S with type key = Model.Role.t
+module Make(Input : S.SOLVER_INPUT) : sig
+  module Output : S.SOLVER_RESULT with module Input = Input
 
   (** [do_solve model req] finds an implementation matching the given requirements, plus any other implementations needed
-   * to satisfy its dependencies.
-   * @param dummy_impl adds a lowest-ranked (but valid) implementation to
-   *   every interface, so we can always select something. Useful for diagnostics.
-   *   You should ensure that [Model.get_command] always returns a dummy command for dummy_impl too.
-   *   Note: always try without a [dummy_impl] first, or it may miss a valid solution.
-   * @return None if the solve fails (only happens if [closest_match] is false). *)
-  val do_solve : ?dummy_impl:Model.impl -> Model.requirements -> selection RoleMap.t option
-
-  (** Request diagnostics-of-last-resort (fallback used when [Diagnostics] can't work out what's wrong).
-   * Gets a report from the underlying SAT solver. *)
-  val explain : diagnostics -> string
+      to satisfy its dependencies.
+      @param closest_match adds a lowest-ranked (but valid) implementation ([Input.dummy_impl]) to
+        every interface, so we can always select something. Useful for diagnostics.
+        You should ensure that [Input.get_command] always returns a dummy command for dummy_impl too.
+        Note: always try without [closest_match] first, or it may miss a valid solution.
+      @return None if the solve fails (only happens if [closest_match] is false). *)
+  val do_solve : closest_match:bool -> Input.requirements -> Output.t option
 end
 
 (** Explaining why a solve failed or gave an unexpected answer. *)

--- a/ocaml/tests/test_sat.ml
+++ b/ocaml/tests/test_sat.ml
@@ -132,7 +132,7 @@ let run_sat_test expected problem =
     )
   );
 
-  let root_req = { Solver.Model.
+  let root_req = { Solver.Input.
     role = {
       Solver.scope = (impl_provider :> Impl_provider.impl_provider);
       iface = fst @@ List.hd expected_items;

--- a/ocaml/tests/test_solver.ml
+++ b/ocaml/tests/test_solver.ml
@@ -621,7 +621,7 @@ let suite = "solver">::: [
         Scope_filter.machine_ranks = Arch.get_machine_ranks machine ~multiarch:true;
       } in
       let impl_provider = make_impl_provider config scope_filter in
-      let root_req = { Solver.Model.
+      let root_req = { Solver.Input.
         role = {
           Solver.scope = impl_provider;
           iface = "http://foo/MultiArch.xml";
@@ -687,7 +687,7 @@ let suite = "solver">::: [
         languages = Support.Locale.score_langs [Fake_system.expect @@ Support.Locale.parse_lang lang];
       } in
       let impl_provider = new Impl_provider.default_impl_provider config feed_provider scope_filter in
-      let root_req = { Solver.Model.
+      let root_req = { Solver.Input.
         role = {
           Solver.scope = impl_provider;
           iface = Fake_system.test_data "Langs.xml";

--- a/ocaml/zeroinstall/driver.mli
+++ b/ocaml/zeroinstall/driver.mli
@@ -32,7 +32,7 @@ val solve_with_downloads :
   Requirements.t ->
   force:bool ->
   update_local:bool ->
-  (bool * Solver.Model.t * Feed_provider.feed_provider) Lwt.t
+  (bool * Solver.Output.t * Feed_provider.feed_provider) Lwt.t
 
 (** Convenience wrapper for [fetcher#download_and_import_feed] that just gives the final result.
  * If the mirror replies first, but the primary succeeds, we return the primary. *)

--- a/ocaml/zeroinstall/exec.ml
+++ b/ocaml/zeroinstall/exec.ml
@@ -97,7 +97,7 @@ let do_exec_binding dry_run builder env impls (role, {Binding.exec_type; Binding
 
 (* Make a map from InterfaceURIs to the selected <selection> and (for non-native packages) paths *)
 let make_selection_map system stores sels =
-  Selections.as_map sels |> Selections.RoleMap.mapi (fun role sel ->
+  Selections.to_map sels |> Selections.RoleMap.mapi (fun role sel ->
     let path =
       try Selections.get_path system stores sel
       with Stores.Not_stored msg ->

--- a/ocaml/zeroinstall/gui.ml
+++ b/ocaml/zeroinstall/gui.ml
@@ -108,7 +108,7 @@ let have_source_for feed_provider iface =
 let list_impls results role =
   let {Solver.iface; source; scope = _} = role in
   let impl_provider = Solver.impl_provider role in
-  let selected_impl = Solver.Model.get_selected role results in
+  let selected_impl = Solver.Output.get_selected role results |> map_some Solver.Output.unwrap in
   let candidates = impl_provider#get_implementations iface ~source in
 
   let by_version (a,_) (b,_) = compare b.Impl.parsed_version a.Impl.parsed_version in
@@ -251,7 +251,7 @@ let compile config feed_provider iface ~autocompile =
 let get_bug_report_details config ~role (ready, results) =
   let system = config.system in
   let sels = Solver.selections results in
-  let root_role = Solver.Model.((requirements results).role) in
+  let root_role = Solver.Output.((requirements results).role) in
   let issue_file = "/etc/issue" in
   let issue =
     if system#file_exists issue_file then
@@ -264,9 +264,9 @@ let get_bug_report_details config ~role (ready, results) =
     let do_add msg = Buffer.add_string b msg in
     Format.kasprintf do_add fmt in
 
-  add "Problem with %a\n" Solver.Model.Role.pp role;
+  add "Problem with %a\n" Solver.Output.Role.pp role;
   if role <> root_role then
-    add "  (while attempting to run %a)\n" Solver.Model.Role.pp root_role;
+    add "  (while attempting to run %a)\n" Solver.Output.Role.pp root_role;
   add "\n";
 
   add "0install version %s\n" About.version;

--- a/ocaml/zeroinstall/gui.mli
+++ b/ocaml/zeroinstall/gui.mli
@@ -51,20 +51,20 @@ val have_source_for : Feed_provider.feed_provider -> Sigs.iface_uri -> bool
 
 (** List the implementations of this interface in the order they should be shown in the GUI.
  * @return (selected_version, implementations). *)
-val list_impls : Solver.Model.t -> Solver.role ->
+val list_impls : Solver.Output.t -> Solver.role ->
   (Impl.generic_implementation option * (Impl.generic_implementation * Impl_provider.rejection_reason option) list)
 
 (* Returns (fetch-size, fetch-tooltip) *)
 val get_fetch_info : General.config -> Impl.generic_implementation -> (string * string)
 
 (** Get the initial text for the bug report dialog box. *)
-val get_bug_report_details : General.config -> role:Solver.role -> (bool * Solver.Model.t) -> string
+val get_bug_report_details : General.config -> role:Solver.role -> (bool * Solver.Output.t) -> string
 
 (** Submit a bug report for this interface.
  * @return the response from the server (on success).
  * @raise Safe_exn.T on failure. *)
 val send_bug_report : Sigs.iface_uri -> string -> string Lwt.t
 
-val run_test : General.config -> Distro.t -> (Selections.t -> string Lwt.t) -> (bool * Solver.Model.t) -> string Lwt.t
+val run_test : General.config -> Distro.t -> (Selections.t -> string Lwt.t) -> (bool * Solver.Output.t) -> string Lwt.t
 
 val generate_feed_description : General.config -> Trust.trust_db -> Feed.t -> Feed_metadata.t -> feed_description Lwt.t

--- a/ocaml/zeroinstall/progress.mli
+++ b/ocaml/zeroinstall/progress.mli
@@ -14,7 +14,7 @@ class type watcher =
 
     (* Updates the latest solution. If the first argument is [true] then the solve is
      * usable (although it may improve if you wait). *)
-    method update : (bool * Solver.Model.t) * Feed_provider.feed_provider -> unit
+    method update : (bool * Solver.Output.t) * Feed_provider.feed_provider -> unit
 
     (** A new download has been added (may still be queued). *)
     method monitor : Downloader.download -> unit

--- a/ocaml/zeroinstall/selections.ml
+++ b/ocaml/zeroinstall/selections.ml
@@ -59,7 +59,7 @@ type dep_info = {
   dep_required_commands : command_name list;
 }
 
-let as_map t = t.index
+let to_map t = t.index
 
 let re_initial_slash = Str.regexp "^/"
 let re_package = Str.regexp "^package:"
@@ -215,11 +215,8 @@ let requires _role impl = make_deps (Element.deps_and_bindings impl)
 let command_requires _role command = make_deps (Element.command_children command)
 let get_command sel name = Element.get_command name sel
 
-let selected_commands sels role =
-  match get_selected role sels with
-  | None -> []
-  | Some sel ->
-      Element.deps_and_bindings sel |> U.filter_map (function
-        | `Command c -> Some (Element.command_name c)
-        | _ -> None
-      )
+let selected_commands sel =
+  Element.deps_and_bindings sel |> U.filter_map (function
+      | `Command c -> Some (Element.command_name c)
+      | _ -> None
+    )

--- a/ocaml/zeroinstall/selections.mli
+++ b/ocaml/zeroinstall/selections.mli
@@ -58,9 +58,6 @@ val as_xml : t -> Support.Qdom.element
 (** Return all bindings *)
 val collect_bindings : t -> (role * Element.binding) list
 
-(** [as_map t] is the map of the selections in [t]. *)
-val as_map : t -> selection RoleMap.t
-
 (** {2 Selection elements} *)
 
 val get_source : selection -> impl_source

--- a/ocaml/zeroinstall/solver.mli
+++ b/ocaml/zeroinstall/solver.mli
@@ -11,31 +11,33 @@ type role = {
   source : bool;
 }
 
-module Model : Zeroinstall_solver.S.SOLVER_RESULT with
+module Input : Zeroinstall_solver.S.SOLVER_INPUT with
   type Role.t = role and
   type impl = Impl.generic_implementation
 
-val selections : Model.t -> Selections.t
+module Output : Zeroinstall_solver.S.SOLVER_RESULT with module Input = Input
+
+val selections : Output.t -> Selections.t
 
 (** Get the impl_provider used for this role. Useful for diagnostics and in the GUI to list the candidates. *)
 val impl_provider : role -> Impl_provider.impl_provider
 
 (** Convert [Requirements.t] to requirements for the solver.
  * This looks at the host system to get some values (whether we have multi-arch support, default CPU and OS). *)
-val get_root_requirements : General.config -> Requirements.t -> (Scope_filter.t -> Impl_provider.impl_provider) -> Model.requirements
+val get_root_requirements : General.config -> Requirements.t -> (Scope_filter.t -> Impl_provider.impl_provider) -> Input.requirements
 
 (** Find a set of implementations which satisfy these requirements. Consider using [solve_for] instead.
     @param closest_match adds a lowest-ranked (but valid) implementation to every interface, so we can always
            select something. Useful for diagnostics.
-    @return None if the solve fails (only happens if [closest_match] is false. *)
-val do_solve : Model.requirements -> closest_match:bool -> Model.t option
+    @return None if the solve fails (only happens if [closest_match] is false). *)
+val do_solve : closest_match:bool -> Input.requirements -> Output.t option
 
 (** High-level solver interface.
  * Runs [do_solve ~closest_match:false] and reports (true, results) on success.
  * On failure, tries again with [~closest_match:true] and reports (false, results) for diagnostics. *)
-val solve_for : General.config -> Feed_provider.feed_provider -> Requirements.t -> bool * Model.t
+val solve_for : General.config -> Feed_provider.feed_provider -> Requirements.t -> bool * Output.t
 
 (** Why did this solve fail? We take the partial solution from the solver and show,
     for each component we couldn't select, which constraints caused the candidates
     to be rejected. *)
-val get_failure_reason : General.config -> Model.t -> string
+val get_failure_reason : General.config -> Output.t -> string

--- a/ocaml/zeroinstall/tree.ml
+++ b/ocaml/zeroinstall/tree.ml
@@ -39,7 +39,7 @@ module Make (Model : Sigs.SELECTIONS) = struct
                 let impl_deps, _self_commands = Model.requires role impl in
                 let deps = ref impl_deps in
 
-                Model.selected_commands result role |> List.iter (fun command_name ->
+                Model.selected_commands impl |> List.iter (fun command_name ->
                   let command = Model.get_command impl command_name
                     |? lazy (Safe_exn.failf "BUG: Missing selected command '%s'!" (command_name : Model.command_name :> string)) in
                   let command_deps, _self_commands = Model.command_requires role command in


### PR DESCRIPTION
The old API was a bit confusing. The user of the solver had to wrap the solver's return to provide a `SOLVER_RESULT` for the diagnostics.

Now, the user-required bits are in `SOLVER_INPUT` and the solver itself provides the rest.