### PR TITLE
Require lablgtk3 >= 3

### DIFF
--- a/0install-gtk.opam
+++ b/0install-gtk.opam
@@ -13,7 +13,7 @@ depends: [
   "0install" {= version}
   "ounit" {with-test}
   "dune" {>= "2.1"}
-  "lablgtk3"
+  "lablgtk3" {>= "3"}
   "lwt_glib"
 ]
 description: """


### PR DESCRIPTION
Otherwise, we might select one of the old beta releases, which doesn't work.