### PR TITLE
Allow solver to be used outside of 0install

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: avsm/setup-ocaml@master
       with:
         ocaml-version: ${{ matrix.ocaml-version }}
+    - run: opam pin add 0install-solver.dev -n .
     - run: opam pin add 0install.dev -n .
     - run: opam pin add 0install-gtk.dev -n .
     - run: opam depext -yt 0install-gtk

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: bash .travis-extra-deps.sh
 env:
   global:
     - POST_INSTALL_HOOK="bash .travis-test-compile.sh"
-    - PINS="0install.dev:. 0install-gtk.dev:."
+    - PINS="0install-solver.dev:. 0install.dev:. 0install-gtk.dev:."
 jobs:
   include:
     - env: OCAML_VERSION=4.08 PACKAGE="0install"

--- a/0install-solver.opam
+++ b/0install-solver.opam
@@ -11,6 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "2.1"}
+  "ounit2" {with-test}
 ]
 description: """
 A package dependency resolver based on a SAT solver. This was originally

--- a/0install-solver.opam
+++ b/0install-solver.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Package dependency solver"
+maintainer: "talex5@gmail.com"
+authors: "zero-install-devel@lists.sourceforge.net"
+homepage: "https://docs.0install.net/developers/solver/"
+bug-reports: "https://github.com/0install/0install/issues"
+dev-repo: "git+https://github.com/0install/0install.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.1"}
+]
+description: """
+A package dependency resolver based on a SAT solver. This was originally
+written for the 0install package manager, but is now generic and is also used
+as a solver backend for opam.
+The SAT solver is based on MiniSat (http://minisat.se/Papers.html) and
+the application to package management is based on OPIUM (Optimal Package
+Install/Uninstall Manager). 0install-solver uses a (novel?) strategy to find
+the optimal solution extremely quickly (even for a SAT-based solver).
+"""

--- a/0install.opam
+++ b/0install.opam
@@ -10,6 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
+  "0install-solver"
   "yojson"
   "xmlm"
   "ounit" {with-test}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   FORK_USER: ocaml
   FORK_BRANCH: master
   CYG_ROOT: C:\cygwin64
-  PINS: 0install.dev:. 0install-gtk.dev:.
+  PINS: 0install.dev:. 0install-gtk.dev:. 0install-solver.dev:.
   PACKAGE: 0install
 
 install:

--- a/src/solver/dune
+++ b/src/solver/dune
@@ -1,2 +1,3 @@
 (library
- (name zeroinstall_solver))
+ (name zeroinstall_solver)
+ (public_name 0install-solver))

--- a/src/solver/s.ml
+++ b/src/solver/s.ml
@@ -108,6 +108,10 @@ module type SOLVER_INPUT = sig
 
   val machine_group : impl -> machine_group option
 
+  (** There can be only one implementation in each conflict class. *)
+  type conflict_class = private string
+  val conflict_class : impl -> conflict_class list
+
   (** {2 The following are used for diagnostics only} *)
 
   (** The reason why the model rejected an implementation before it got to the solver.

--- a/src/solver/tests/dune
+++ b/src/solver/tests/dune
@@ -1,0 +1,4 @@
+(test
+  (name test)
+  (package 0install-solver)
+  (libraries ounit2 0install-solver))

--- a/src/solver/tests/test.ml
+++ b/src/solver/tests/test.ml
@@ -4,6 +4,8 @@
 
 open OUnit2
 
+let assert_string_equal a b = assert_equal ~printer:(fun x -> x) a b
+
 module StringData =
   struct
     type t = string
@@ -11,6 +13,128 @@ module StringData =
   end
 
 module Sat = Zeroinstall_solver.Sat.Make(StringData)
+
+module Model = struct
+  type command = string
+  type command_name = string
+
+  type restriction = [`Not_before of int]
+
+  type role = string * impl list
+  and dep_info = {
+    dep_role : role;
+    dep_importance : [ `Essential | `Recommended | `Restricts ];
+    dep_required_commands : command_name list;
+  }
+  and impl = {
+    version : int;
+    impl_deps : dependency list;
+    conflict_class : string list;
+  }
+  and dependency = role * restriction list
+
+  module Role = struct
+    type t = role
+    let pp f (id, _) = Format.pp_print_string f id
+    let compare a b = compare (fst a) (fst b)
+  end
+
+  type requirements = {
+    role : Role.t;
+    command : command_name option;
+  }
+
+  let requires _role impl = impl.impl_deps, []
+
+  let dep_info (dep_role, _) = { dep_role; dep_importance = `Essential; dep_required_commands = [] }
+
+  let command_requires _role _command = [], []
+
+  let get_command _impl _ = None
+
+  type role_information = {
+    replacement : Role.t option;
+    impls : impl list;
+  }
+
+  type machine_group = string
+
+  let pp_impl f impl = Format.pp_print_int f impl.version
+  let pp_command = Format.pp_print_string
+
+  let implementations (_, impls) = { replacement = None; impls }
+
+  let restrictions (_, rs) = rs
+  let meets_restriction impl (`Not_before min) = impl.version >= min
+
+  let machine_group _impl = None
+
+  type conflict_class = string
+  let conflict_class impl = impl.conflict_class
+
+  type rejection = string
+
+  let rejects _role = [], []
+
+  let compare_version a b = compare b.version a.version
+  let format_version impl = string_of_int impl.version
+
+  let user_restrictions _role = None
+
+  let id_of_impl impl = string_of_int impl.version
+  let format_machine _impl = "(any)"
+  let string_of_restriction (`Not_before x) = Printf.sprintf ">= %d" x
+  let describe_problem _impl x = x
+
+  let dummy_impl = { version = -1; impl_deps = []; conflict_class = [] }
+end
+
+module Opam_test = struct
+  open Model
+
+  let ocaml_4_08 = { version = 408; impl_deps = []; conflict_class = ["compiler"] }
+  let beta_ocaml_4_09 = { version = 409; impl_deps = []; conflict_class = ["compiler"] }
+  let ocaml_compiler = "ocaml", [ocaml_4_08]
+  let beta_ocaml_compiler = "beta-ocaml", [beta_ocaml_4_09]
+
+  let app = { version = 1;
+              conflict_class = [];
+              impl_deps = [
+                ocaml_compiler, [];
+                beta_ocaml_compiler, [];
+              ]
+            }
+
+  let app_role = "app", [app]
+
+  let expected = String.trim {|
+Can't find all required implementations:
+- app -> 1 (1)
+- beta-ocaml -> (problem)
+    Rejected candidates:
+      409 (409): In same conflict class (compiler) as ocaml
+- ocaml -> 408 (408)
+|}
+
+end
+
+module Solver = Zeroinstall_solver.Make(Model)
+module Diagnostics = Zeroinstall_solver.Diagnostics(Solver.Output)
+
+let get_diagnostics reqs =
+  match Solver.do_solve ~closest_match:false reqs with
+  | Some s ->
+    let b = Buffer.create 1024 in
+    Buffer.add_string b "Solve should have failed, but got:\n";
+    Solver.Output.to_map s |> Solver.Output.RoleMap.iter (fun (role, _) impl ->
+        let msg = Printf.sprintf "%s -> %d\n" role (Solver.Output.unwrap impl).Model.version in
+        Buffer.add_string b msg
+      );
+    OUnit2.assert_failure (Buffer.contents b)
+  | None ->
+    match Solver.do_solve ~closest_match:true reqs with
+    | None -> OUnit2.assert_failure "Diagnostics should not have failed!"
+    | Some results -> Diagnostics.get_failure_reason results
 
 let suite = "solver">::: [
   "sat_simple">:: (fun _ ->
@@ -98,6 +222,11 @@ let suite = "solver">::: [
         assert (solution p1 = false);
         assert (solution p2 = true);
   );
+
+  "conflict-classes">:: (fun _ ->
+      let reqs = { Model.role = Opam_test.app_role; command = None } in
+      assert_string_equal Opam_test.expected @@ get_diagnostics reqs
+    )
 ]
 
 let () =

--- a/src/solver/tests/test.ml
+++ b/src/solver/tests/test.ml
@@ -1,0 +1,104 @@
+(* Copyright (C) 2020, Thomas Leonard
+ * See the README file for details, or visit http://0install.net.
+ *)
+
+open OUnit2
+
+module StringData =
+  struct
+    type t = string
+    let pp = Format.pp_print_string
+  end
+
+module Sat = Zeroinstall_solver.Sat.Make(StringData)
+
+let suite = "solver">::: [
+  "sat_simple">:: (fun _ ->
+    let open Sat in
+    let problem = create () in
+
+    let p1 = add_variable problem "p1" in
+    let p2 = add_variable problem "p2" in
+
+    let lib1 = add_variable problem "lib1" in
+    let lib2 = add_variable problem "lib2" in
+
+    let decider () = Some p1 in
+
+    ignore @@ at_most_one problem [p1; p2];
+    ignore @@ at_most_one problem [lib1; lib2];
+
+    at_least_one problem [neg p1; lib1];
+    at_least_one problem [neg p2; lib2];
+
+    match run_solver problem decider with
+    | None -> assert false
+    | Some solution ->
+        assert (solution p1 = true);
+        assert (solution p2 = false);
+
+        assert (solution lib1 = true);
+        assert (solution lib2 = false)
+  );
+
+  "sat_analyse">:: (fun _ ->
+    let open Sat in
+    let problem = create () in
+
+    let p1 = add_variable problem "p1" in
+    let p2 = add_variable problem "p2" in
+
+    let lib1 = add_variable problem "lib1" in
+    let lib2 = add_variable problem "lib2" in
+
+    let conf1 = add_variable problem "conf1" in
+
+    let decider () = Some p1 in
+
+    at_least_one problem [p1; p2];
+    ignore @@ at_most_one problem [p1; p2];
+    ignore @@ at_most_one problem [lib1; lib2];
+
+    (* p1 requires lib1 or lib2 *)
+    at_least_one problem [neg p1; lib1; lib2];
+    at_least_one problem [neg p2; lib1];
+
+    (* p1 requires conf1, which conflicts with lib1 and lib2 *)
+    at_least_one problem [neg p1; conf1];
+    at_least_one problem [neg conf1; neg lib1];
+    at_least_one problem [neg conf1; neg lib2];
+
+    (* We try p1 first. That requires (lib1 or lib2) and conf1.
+      conf1 conflicts with lib, causing us to analyse the problem
+      and backtrack. *)
+
+    match run_solver problem decider with
+    | None -> assert false
+    | Some solution ->
+        assert (solution p1 = false);
+        assert (solution p2 = true);
+
+        assert (solution lib1 = true);
+        assert (solution lib2 = false);
+  );
+
+  "sat_at_most">:: (fun _ ->
+    let open Sat in
+    let problem = create () in
+
+    let p1 = add_variable problem "p1" in
+    let p2 = add_variable problem "p2" in
+
+    ignore @@ at_most_one problem [neg p1; neg p2];
+
+    let decider () = Some (neg p1) in
+    match run_solver problem decider with
+    | None -> assert false
+    | Some solution ->
+        assert (solution p1 = false);
+        assert (solution p2 = true);
+  );
+]
+
+let () =
+  OUnit2.run_test_tt_main suite

--- a/src/solver/zeroinstall_solver.mli
+++ b/src/solver/zeroinstall_solver.mli
@@ -29,6 +29,7 @@ module Diagnostics(Result : S.SOLVER_RESULT) : sig
       | `FailsRestriction of Result.Input.restriction
       | `DepFailsRestriction of Result.Input.dependency * Result.Input.restriction
       | `MachineGroupConflict of Result.Role.t * Result.Input.impl
+      | `ClassConflict of Result.Role.t * Result.Input.conflict_class
       | `ConflictsRole of Result.Role.t
       | `MissingCommand of Result.Input.command_name
       | `DiagnosticsFailure of string

--- a/src/solver/zeroinstall_solver.mli
+++ b/src/solver/zeroinstall_solver.mli
@@ -20,12 +20,68 @@ module Make(Input : S.SOLVER_INPUT) : sig
 end
 
 (** Explaining why a solve failed or gave an unexpected answer. *)
-module Diagnostics(Model : S.SOLVER_RESULT) : sig
-  (** Why did this solve fail? We take the partial solution from the solver and show,
-      for each component we couldn't select, which constraints caused the candidates
-      to be rejected.
-      @param verbose List all rejected candidates, not just the first few. *)
-  val get_failure_reason : ?verbose:bool -> Model.t -> string
+module Diagnostics(Result : S.SOLVER_RESULT) : sig
+
+  (** An item of information to display for a component. *)
+  module Note : sig
+    type rejection_reason = [
+      | `Model_rejection of Result.Input.rejection
+      | `FailsRestriction of Result.Input.restriction
+      | `DepFailsRestriction of Result.Input.dependency * Result.Input.restriction
+      | `MachineGroupConflict of Result.Role.t * Result.Input.impl
+      | `ConflictsRole of Result.Role.t
+      | `MissingCommand of Result.Input.command_name
+      | `DiagnosticsFailure of string
+    ]
+    (** Why a particular implementation was rejected. This could be because the
+        input rejected it before it got to the solver, or because it conflicts
+        with something else in the example (partial) solution. *)
+
+    type t =
+      | UserRequested of Result.Input.restriction
+      | ReplacesConflict of Result.Role.t
+      | ReplacedByConflict of Result.Role.t
+      | Restricts of Result.Role.t * Result.Input.impl * Result.Input.restriction list
+      | RequiresCommand of Result.Role.t * Result.Input.impl * Result.Input.command_name
+      | Feed_problem of string
+      | NoCandidates of {
+          reason : [`No_candidates | `No_usable_candidates | `Rejected_candidates];
+          rejects : (Result.Input.impl * rejection_reason) list;
+        }
+
+    val pp : verbose:bool -> Format.formatter -> t -> unit
+    (** [pp_note ~verbose] is a formatter for notes.
+        @param verbose If [false], limit the list of rejected candidates (if any) to five entries. *)
+  end
+
+  (** Information about a single role in the example (failed) selections produced by the solver. *)
+  module Component : sig
+    type t
+
+    val selected_impl : t -> Result.Input.impl option
+    (** [selected_impl t] is the implementation selected to fill [t]'s role, or
+        [None] if no implementation was suitable. *)
+
+    val notes : t -> Note.t list
+    (** Information discovered about this component. *)
+
+    val pp : verbose:bool -> Format.formatter -> t -> unit
+    (** [pp ~verbose] formats a message showing the status of this component,
+        including all of its notes. *)
+  end
+
+  type t = Component.t Result.RoleMap.t
+  (** An analysis of why the solve failed. *)
+
+  val of_result : Result.t -> t
+  (** [of_result r] is an analysis of failed solver result [r].
+      We take the partial solution from the solver and discover, for each
+      component we couldn't select, which constraints caused the candidates to
+      be rejected. *)
+
+  val get_failure_reason : ?verbose:bool -> Result.t -> string
+  (** [get_failure_reason r] analyses [r] with [of_result] and formats the
+      analysis as a string. *)
 end
 
 (** The low-level SAT solver. *)

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -13,4 +13,4 @@
   (package 0install)
   (deps (source_tree data)
    0install%{ext_exe} 0install-runenv%{ext_exe})
-  (libraries oUnit zeroinstall zeroinstall_cli zeroinstall_solver support lwt lwt.unix lwt_react xmlm yojson))
+  (libraries oUnit zeroinstall zeroinstall_cli 0install-solver support lwt lwt.unix lwt_react xmlm yojson))

--- a/src/tests/test_solver.ml
+++ b/src/tests/test_solver.ml
@@ -11,17 +11,6 @@ open Zeroinstall
 module Q = Support.Qdom
 module U = Support.Utils
 
-module StringData =
-  struct
-    type t = string
-    let pp = Format.pp_print_string
-    let unused = "unused"
-  end
-
-module Sat = Zeroinstall_solver.Sat.Make(StringData)
-
-open Sat
-
 module EString =
 struct
   type t = string
@@ -262,89 +251,6 @@ let make_solver_test test_elem =
   )
 
 let suite = "solver">::: [
-  "sat_simple">:: (fun () ->
-    let problem = create () in
-
-    let p1 = add_variable problem "p1" in
-    let p2 = add_variable problem "p2" in
-
-    let lib1 = add_variable problem "lib1" in
-    let lib2 = add_variable problem "lib2" in
-
-    let decider () = Some p1 in
-
-    ignore @@ at_most_one problem [p1; p2];
-    ignore @@ at_most_one problem [lib1; lib2];
-
-    at_least_one problem [neg p1; lib1];
-    at_least_one problem [neg p2; lib2];
-
-    match run_solver problem decider with
-    | None -> assert false
-    | Some solution ->
-        assert (solution p1 = true);
-        assert (solution p2 = false);
-
-        assert (solution lib1 = true);
-        assert (solution lib2 = false)
-  );
-
-  "sat_analyse">:: (fun () ->
-    let problem = create () in
-
-    let p1 = add_variable problem "p1" in
-    let p2 = add_variable problem "p2" in
-
-    let lib1 = add_variable problem "lib1" in
-    let lib2 = add_variable problem "lib2" in
-
-    let conf1 = add_variable problem "conf1" in
-
-    let decider () = Some p1 in
-
-    at_least_one problem [p1; p2];
-    ignore @@ at_most_one problem [p1; p2];
-    ignore @@ at_most_one problem [lib1; lib2];
-
-    (* p1 requires lib1 or lib2 *)
-    at_least_one problem [neg p1; lib1; lib2];
-    at_least_one problem [neg p2; lib1];
-
-    (* p1 requires conf1, which conflicts with lib1 and lib2 *)
-    at_least_one problem [neg p1; conf1];
-    at_least_one problem [neg conf1; neg lib1];
-    at_least_one problem [neg conf1; neg lib2];
-
-    (* We try p1 first. That requires (lib1 or lib2) and conf1.
-      conf1 conflicts with lib, causing us to analyse the problem
-      and backtrack. *)
-
-    match run_solver problem decider with
-    | None -> assert false
-    | Some solution ->
-        assert (solution p1 = false);
-        assert (solution p2 = true);
-
-        assert (solution lib1 = true);
-        assert (solution lib2 = false);
-  );
-
-  "sat_at_most">:: (fun () ->
-    let problem = create () in
-
-    let p1 = add_variable problem "p1" in
-    let p2 = add_variable problem "p2" in
-
-    ignore @@ at_most_one problem [neg p1; neg p2];
-
-    let decider () = Some (neg p1) in
-    match run_solver problem decider with
-    | None -> assert false
-    | Some solution ->
-        assert (solution p1 = false);
-        assert (solution p2 = true);
-  );
-
   "feed_provider">:: (fun () ->
     let open Feed_cache in
     let (config, fake_system) = Fake_system.get_fake_config None in

--- a/src/zeroinstall/dune
+++ b/src/zeroinstall/dune
@@ -1,7 +1,7 @@
 (library
  (name        zeroinstall)
  (modules_without_implementation feed_provider progress sigs ui)
- (libraries dynlink lwt lwt.unix react lwt_react support yojson xmlm zeroinstall_solver
+ (libraries dynlink lwt lwt.unix react lwt_react support yojson xmlm 0install-solver
             (select http.ml from
              (curl curl.lwt -> http.curl.ml)
              (cohttp cohttp-lwt cohttp-lwt-unix lwt_ssl -> http.cohttp.ml)

--- a/src/zeroinstall/solver.ml
+++ b/src/zeroinstall/solver.ml
@@ -146,6 +146,9 @@ module Input = struct
     XString.Map.find_opt role.iface role.scope#extra_restrictions
 
   let format_version impl = Version.to_string impl.Impl.parsed_version
+
+  type conflict_class = private string
+  let conflict_class _ = []
 end
 
 include Zeroinstall_solver.Make(Input)


### PR DESCRIPTION
This PR aims to make 0install's solver usable by other package managers:

- Move the solver to its own opam package (`0install-solver`).
- Add support for "conflict classes". opam uses this to make every compiler conflict with every other compiler, even when they have different names.
- Clean up the Diagnostics code and extend the public API. The default format is designed for 0install and assumes long package names and hashes. This also gives some flexibility in controlling how verbose the output should be.

As an example, https://github.com/talex5/opam-0install-solver uses this to speed up opam.