### PR TITLE
Depend on ounit2 for unit-tests

### DIFF
--- a/0install-gtk.opam
+++ b/0install-gtk.opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "0install" {= version}
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "dune" {>= "2.1"}
   "lablgtk3" {>= "3"}
   "lwt_glib"

--- a/0install.opam
+++ b/0install.opam
@@ -13,7 +13,7 @@ depends: [
   "0install-solver"
   "yojson"
   "xmlm"
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "lwt"
   "lwt_react"
   "obus" {os != "macos" & os-family != "windows"}

--- a/src/test_gtk/dune
+++ b/src/test_gtk/dune
@@ -13,4 +13,4 @@
   (package 0install-gtk)
   (deps (alias ../../install)     ; Build the GTK plugin if possible
         0install%{ext_exe} 0install-runenv%{ext_exe})
-  (libraries oUnit zeroinstall support str))
+  (libraries ounit2 zeroinstall support str))

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -13,4 +13,4 @@
   (package 0install)
   (deps (source_tree data)
    0install%{ext_exe} 0install-runenv%{ext_exe})
-  (libraries oUnit zeroinstall zeroinstall_cli 0install-solver support lwt lwt.unix lwt_react xmlm yojson))
+  (libraries ounit2 zeroinstall zeroinstall_cli 0install-solver support lwt lwt.unix lwt_react xmlm yojson))

--- a/src/tests/fake_system.ml
+++ b/src/tests/fake_system.ml
@@ -10,7 +10,7 @@ module Config = Zeroinstall.Config
 module U = Support.Utils
 
 let reset_env () =
-  (* Make oUnit 2 happy: we need to be able to reset these to their initial values after each test. *)
+  (* Make OUnit 2 happy: we need to be able to reset these to their initial values after each test. *)
   Unix.putenv "ZEROINSTALL_PORTABLE_BASE" "/PORTABLE_UNUSED";
   Unix.putenv "DISPLAY" "";
   Unix.putenv "DBUS_SESSION_BUS_ADDRESS" "DBUS_SESSION_UNUSED";


### PR DESCRIPTION
The old `oUnit` is just a transition package that depends on `ounit2` now.