### PR TITLE
Only report restrictions that affected the result

### DIFF
--- a/src/solver/diagnostics.ml
+++ b/src/solver/diagnostics.ml
@@ -13,7 +13,6 @@ module Make (Results : S.SOLVER_RESULT) = struct
   module RoleMap = Results.RoleMap
 
   let format_role = Model.Role.pp
-  let format_version f v = Format.pp_print_string f (Model.format_version v)
   let format_restrictions r = String.concat ", " (List.map Model.string_of_restriction r)
 
   module Note = struct
@@ -30,9 +29,9 @@ module Make (Results : S.SOLVER_RESULT) = struct
       | ReplacesConflict old -> pf f "Replaces (and therefore conflicts with) %a" format_role old
       | ReplacedByConflict replacement -> pf f "Replaced by (and therefore conflicts with) %a" format_role replacement
       | Restricts (other_role, impl, r) ->
-        pf f "%a %a requires %s" format_role other_role format_version impl (format_restrictions r)
+        pf f "%a %a requires %s" format_role other_role Model.pp_version impl (format_restrictions r)
       | RequiresCommand (other_role, impl, command) ->
-        pf f "%a %a requires '%s' command" format_role other_role format_version impl (command :> string)
+        pf f "%a %a requires '%s' command" format_role other_role Model.pp_version impl (command :> string)
       | Feed_problem msg -> pf f "%s" msg
   end
 
@@ -190,7 +189,7 @@ module Make (Results : S.SOLVER_RESULT) = struct
         | [] -> ()
         | _ when i = 5 && not verbose -> pf f "@,..."
         | (impl, problem) :: xs ->
-          pf f "@,%s (%a): %a" (Model.id_of_impl impl) format_version impl pp_reject (impl, problem);
+          pf f "@,%a: %a" Model.pp_impl_long impl pp_reject (impl, problem);
           aux (i + 1) xs
       in
       aux 0 rejected
@@ -218,7 +217,7 @@ module Make (Results : S.SOLVER_RESULT) = struct
 
     let pp_outcome f t =
       match t.selected_impl with
-      | Some sel -> pf f "%a (%s)" format_version sel (Model.id_of_impl sel)
+      | Some sel -> Model.pp_impl_long f sel
       | None -> Format.pp_print_string f "(problem)"
 
     (* Format a textual description of this component's report. *)

--- a/src/solver/s.ml
+++ b/src/solver/s.ml
@@ -124,13 +124,16 @@ module type SOLVER_INPUT = sig
 
   (** Used to sort the results. *)
   val compare_version : impl -> impl -> int
-  val format_version : impl -> string
+  val pp_version : Format.formatter -> impl -> unit
 
   (** Get any user-specified restrictions affecting a role.
       These are used to filter out implementations before they get to the solver. *)
   val user_restrictions : Role.t -> restriction option
 
-  val id_of_impl : impl -> string
+  (** A detailed identifier for the implementation. In 0install, this is the version
+      number and part of the hash. *)
+  val pp_impl_long : Format.formatter -> impl -> unit
+
   val format_machine : impl -> string
   val string_of_restriction : restriction -> string
   val describe_problem : impl -> rejection -> string

--- a/src/solver/tests/test.ml
+++ b/src/solver/tests/test.ml
@@ -77,11 +77,11 @@ module Model = struct
   let rejects _role = [], []
 
   let compare_version a b = compare b.version a.version
-  let format_version impl = string_of_int impl.version
+  let pp_version f impl = Format.pp_print_int f impl.version
 
   let user_restrictions _role = None
 
-  let id_of_impl impl = string_of_int impl.version
+  let pp_impl_long = pp_version
   let format_machine _impl = "(any)"
   let string_of_restriction (`Not_before x) = Printf.sprintf ">= %d" x
   let describe_problem _impl x = x
@@ -109,11 +109,11 @@ module Opam_test = struct
 
   let expected = String.trim {|
 Can't find all required implementations:
-- app -> 1 (1)
+- app -> 1
 - beta-ocaml -> (problem)
     Rejected candidates:
-      409 (409): In same conflict class (compiler) as ocaml
-- ocaml -> 408 (408)
+      409: In same conflict class (compiler) as ocaml
+- ocaml -> 408
 |}
 
 end

--- a/src/tests/data/driven.xml
+++ b/src/tests/data/driven.xml
@@ -40,7 +40,7 @@
 
     <requirements command='run' interface='./local.xml' fails='true'/>
 
-    <problem>Can't find all required implementations\(.\|\)*/bin (1.0): No run command</problem>
+    <problem>Can't find all required implementations\(.\|\)*v1.0 (/bin): No run command</problem>
   </test>
 
   <test name='need-download'>
@@ -203,7 +203,7 @@ Can't find all required implementations:
       <implementation id='sha1=123' version='1.0' main='dummy'/>
     </interface>
     <requirements command='run' interface='http://foo/' dry-run='true'/>
-    <problem>\(.\|\)*sha1=123 (1.0): No retrieval methods</problem>
+    <problem>\(.\|\)*v1.0 (sha1=123): No retrieval methods</problem>
   </test>
 
   <test name='cycle'>

--- a/src/tests/data/solves.xml
+++ b/src/tests/data/solves.xml
@@ -1174,7 +1174,6 @@ Can't find all required implementations:
     <problem>
 Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
-    http://localhost/top.xml 1 requires version ..!6
     Rejected candidates:
       diag-5 (5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
       diag-4 (4): Can't use x86_64 with selection of http://localhost/top.xml (i486)
@@ -1189,7 +1188,6 @@ Can't find all required implementations:
 There is no possible selection using http://localhost/diagnostics.xml 5.
 Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
-    http://localhost/top.xml 1 requires version ..!6
     Rejected candidates:
       diag-5 (5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
 - http://localhost/top.xml -> 1 (1)
@@ -1656,16 +1654,57 @@ Can't find all required implementations:
     <problem>
 Can't find all required implementations:
 - /root/0publish.xml -> 0.25-post (pub1)
-    /root/0test.xml 0.9-post requires 'run' command
 - /root/0test.xml -> 0.9-post (test1)
 - /root/python.xml -> (problem)
     /root/0publish.xml 0.25-post requires version ..!3
-    /root/0publish.xml 0.25-post requires 'run' command
     /root/0test.xml 0.9-post requires version 3..
-    /root/0test.xml 0.9-post requires 'run' command
     Rejected candidates:
       3 (3): Incompatible with restriction: version ..!3
       2 (2): Incompatible with restriction: version 3..
+    </problem>
+  </test>
+
+  <test name='uninteresting-reject'>
+    <interface local-path='python.xml'>
+      <name>Python</name>
+      <summary>Versions 2 and 3</summary>
+      <group>
+	<command name='run' path='python.exe'/>
+	<implementation id='2' local-path='.' version='2'/>
+	<implementation id='3' local-path='.' version='3'/>
+      </group>
+    </interface>
+
+    <interface local-path='0publish.xml'>
+      <name>0publish</name>
+      <summary>Impossible</summary>
+      <group>
+	<implementation id='pub1' local-path='.' version='0.25-post'/>
+      </group>
+    </interface>
+
+    <interface local-path='0test.xml'>
+      <name>0test</name>
+      <summary>Don't report rejection of Python 2</summary>
+      <group>
+	<command name='test'>
+	  <runner interface='/root/python.xml' version='3..'/>
+	  <requires interface='/root/0publish.xml' version='4..'/>
+	</command>
+	<implementation id='test1' local-path='.' version='0.9-post'/>
+      </group>
+    </interface>
+
+    <requirements fails='true' interface='./0test.xml' command='test'/>
+
+    <problem>
+Can't find all required implementations:
+- /root/0publish.xml -> (problem)
+    /root/0test.xml 0.9-post requires version 4..
+    Rejected candidates:
+      pub1 (0.25-post): Incompatible with restriction: version 4..
+- /root/0test.xml -> 0.9-post (test1)
+- /root/python.xml -> 3 (3)
     </problem>
   </test>
 

--- a/src/tests/data/solves.xml
+++ b/src/tests/data/solves.xml
@@ -729,11 +729,11 @@ Can't find all required implementations:
 - http://example.com/lib.xml -> (problem)
     http://example.com/prog.xml 3 requires version 2..!3
     Rejected candidates:
-      l3 (3): Incompatible with restriction: version 2..!3
-      l2 (2): Requires http://example.com/prog.xml version ..!3
-      l1 (1): Incompatible with restriction: version 2..!3
-      l0 (0): Not compatible with the requested OS type
-- http://example.com/prog.xml -> 3 (p3)
+      v3 (l3): Incompatible with restriction: version 2..!3
+      v2 (l2): Requires http://example.com/prog.xml version ..!3
+      v1 (l1): Incompatible with restriction: version 2..!3
+      v0 (l0): Not compatible with the requested OS type
+- http://example.com/prog.xml -> v3 (p3)
     </justification>
     <justification interface='http://example.com/prog.xml' id='p4'>
       Implementation to consider (http://example.com/prog.xml p4) does not exist!
@@ -778,9 +778,9 @@ Can't find all required implementations:
 - http://example.com/lib.xml -> (problem)
     http://example.com/prog.xml 2 requires version 1..!2
     Rejected candidates:
-      l2 (2): Incompatible with restriction: version 1..!2
-      l1 (1): Requires http://example.com/prog.xml version ..!2
-- http://example.com/prog.xml -> 2 (p2)
+      v2 (l2): Incompatible with restriction: version 1..!2
+      v1 (l1): Requires http://example.com/prog.xml version ..!2
+- http://example.com/prog.xml -> v2 (p2)
     </problem>
   </test>
 
@@ -901,7 +901,7 @@ Can't find all required implementations:
 Can't find all required implementations:
 - http://localhost/top.xml -> (problem)
     No usable implementations:
-      1 (1): No retrieval methods
+      v1 (1): No retrieval methods
    </problem>
  </test>
 
@@ -921,7 +921,7 @@ Can't find all required implementations:
 Can't find all required implementations:
 - http://localhost/top.xml -> (problem)
     Rejected candidates:
-      1 (1): No run command
+      v1 (1): No run command
     </problem>
   </test>
 
@@ -946,8 +946,8 @@ Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     http://localhost/top.xml 1 requires 'foo' command
     Rejected candidates:
-      diag-5 (5): No foo command
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): No foo command
+- http://localhost/top.xml -> v1 (1)
   </problem>
   </test>
 
@@ -970,8 +970,8 @@ Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     http://localhost/top.xml 1 requires distribution:foo
     Rejected candidates:
-      diag-5 (5): Incompatible with restriction: distribution:foo
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): Incompatible with restriction: distribution:foo
+- http://localhost/top.xml -> v1 (1)
   </problem>
   </test>
 
@@ -994,8 +994,8 @@ Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     http://localhost/top.xml 1 requires version 100..!200
     Rejected candidates:
-      diag-5 (5): Incompatible with restriction: version 100..!200
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): Incompatible with restriction: version 100..!200
+- http://localhost/top.xml -> v1 (1)
     </problem>
   </test>
 
@@ -1019,8 +1019,8 @@ Can't find all required implementations:
 Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     Rejected candidates:
-      diag-5 (5): Requires http://localhost/top.xml version 100..!200
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): Requires http://localhost/top.xml version 100..!200
+- http://localhost/top.xml -> v1 (1)
   </problem>
   </test>
 
@@ -1045,8 +1045,8 @@ Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     http://localhost/top.xml 1 requires &lt;impossible: Can't parse version restriction '100..200': End of range must be exclusive (use '..!200', not '..200')>
     Rejected candidates:
-      diag-5 (5): Incompatible with restriction: &lt;impossible: Can't parse version restriction '100..200': End of range must be exclusive (use '..!200', not '..200')>
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): Incompatible with restriction: &lt;impossible: Can't parse version restriction '100..200': End of range must be exclusive (use '..!200', not '..200')>
+- http://localhost/top.xml -> v1 (1)
     </problem>
   </test>
 
@@ -1071,8 +1071,8 @@ Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     http://localhost/top.xml 1 requires version 100..
     Rejected candidates:
-      diag-5 (5): Incompatible with restriction: version 100..
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): Incompatible with restriction: version 100..
+- http://localhost/top.xml -> v1 (1)
     </problem>
   </test>
 
@@ -1098,8 +1098,8 @@ Can't find all required implementations:
 Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     Rejected candidates:
-      diag-5 (5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
+- http://localhost/top.xml -> v1 (1)
     </problem>
   </test>
 
@@ -1128,13 +1128,13 @@ Can't find all required implementations:
 Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     No usable implementations:
-      diag-6 (6): No retrieval methods
-      diag-5 (5): No retrieval methods
-      diag-4 (4): No retrieval methods
-      diag-3 (3): No retrieval methods
-      diag-2 (2): No retrieval methods
+      v6 (diag-6): No retrieval methods
+      v5 (diag-5): No retrieval methods
+      v4 (diag-4): No retrieval methods
+      v3 (diag-3): No retrieval methods
+      v2 (diag-2): No retrieval methods
       ...
-- http://localhost/top.xml -> 1 (1)
+- http://localhost/top.xml -> v1 (1)
     </problem>
   </test>
 
@@ -1175,13 +1175,13 @@ Can't find all required implementations:
 Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     Rejected candidates:
-      diag-5 (5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
-      diag-4 (4): Can't use x86_64 with selection of http://localhost/top.xml (i486)
-      diag-3 (3): Can't use x86_64 with selection of http://localhost/top.xml (i486)
-      diag-2 (2): Can't use x86_64 with selection of http://localhost/top.xml (i486)
-      diag-1 (1): Can't use x86_64 with selection of http://localhost/top.xml (i486)
+      v5 (diag-5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
+      v4 (diag-4): Can't use x86_64 with selection of http://localhost/top.xml (i486)
+      v3 (diag-3): Can't use x86_64 with selection of http://localhost/top.xml (i486)
+      v2 (diag-2): Can't use x86_64 with selection of http://localhost/top.xml (i486)
+      v1 (diag-1): Can't use x86_64 with selection of http://localhost/top.xml (i486)
       ...
-- http://localhost/top.xml -> 1 (1)
+- http://localhost/top.xml -> v1 (1)
     </problem>
 
     <justification interface='http://localhost/diagnostics.xml' id='diag-5'>
@@ -1189,8 +1189,8 @@ There is no possible selection using http://localhost/diagnostics.xml 5.
 Can't find all required implementations:
 - http://localhost/diagnostics.xml -> (problem)
     Rejected candidates:
-      diag-5 (5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
-- http://localhost/top.xml -> 1 (1)
+      v5 (diag-5): Can't use x86_64 with selection of http://localhost/top.xml (i486)
+- http://localhost/top.xml -> v1 (1)
     </justification>
   </test>
 
@@ -1221,10 +1221,10 @@ Can't find all required implementations:
 - http://localhost/diagnostics-old.xml -> (problem)
     Replaced by (and therefore conflicts with) http://localhost/diagnostics.xml
     Rejected candidates:
-      diag-5 (5): Conflicts with http://localhost/diagnostics.xml
-- http://localhost/diagnostics.xml -> 5 (diag-5)
+      v5 (diag-5): Conflicts with http://localhost/diagnostics.xml
+- http://localhost/diagnostics.xml -> v5 (diag-5)
     Replaces (and therefore conflicts with) http://localhost/diagnostics-old.xml
-- http://localhost/top.xml -> 1 (1)
+- http://localhost/top.xml -> v1 (1)
     </problem>
   </test>
 
@@ -1517,7 +1517,7 @@ Can't find all required implementations:
 Can't find all required implementations:
 - /root/prog.xml -> (problem)
     Rejected candidates:
-      . (1): No missing-2 command
+      v1 (.): No missing-2 command
     </problem>
   </test>
 
@@ -1653,14 +1653,14 @@ Can't find all required implementations:
 
     <problem>
 Can't find all required implementations:
-- /root/0publish.xml -> 0.25-post (pub1)
-- /root/0test.xml -> 0.9-post (test1)
+- /root/0publish.xml -> v0.25-post (pub1)
+- /root/0test.xml -> v0.9-post (test1)
 - /root/python.xml -> (problem)
     /root/0publish.xml 0.25-post requires version ..!3
     /root/0test.xml 0.9-post requires version 3..
     Rejected candidates:
-      3 (3): Incompatible with restriction: version ..!3
-      2 (2): Incompatible with restriction: version 3..
+      v3 (3): Incompatible with restriction: version ..!3
+      v2 (2): Incompatible with restriction: version 3..
     </problem>
   </test>
 
@@ -1702,9 +1702,9 @@ Can't find all required implementations:
 - /root/0publish.xml -> (problem)
     /root/0test.xml 0.9-post requires version 4..
     Rejected candidates:
-      pub1 (0.25-post): Incompatible with restriction: version 4..
-- /root/0test.xml -> 0.9-post (test1)
-- /root/python.xml -> 3 (3)
+      v0.25-post (pub1): Incompatible with restriction: version 4..
+- /root/0test.xml -> v0.9-post (test1)
+- /root/python.xml -> v3 (3)
     </problem>
   </test>
 

--- a/src/tests/test_0install.ml
+++ b/src/tests/test_0install.ml
@@ -162,7 +162,7 @@ let suite = "0install">::: [
           "- http://example.com:8000/Hello.xml -> (problem)\n" ^
           "    User requested version 2\n" ^
           "    No usable implementations:\n" ^
-          "      sha1=3ce644dc725f1d21cfcf02562c76f375944b266a (1): Excluded by user-provided restriction: version 2\n" ^
+          "      v1 (sha1=3ce644dc725f...): Excluded by user-provided restriction: version 2\n" ^
           "Note: 0install is in off-line mode") msg in
     ()
   );
@@ -395,7 +395,7 @@ let suite = "0install">::: [
         "- %s/Local.xml -> (problem)\n" ^^
         "    User requested version 10..\n" ^^
         "    No usable implementations:\n" ^^
-        "      sha1=256 (0.1): Excluded by user-provided restriction: version 10..") path)
+        "      v0.1 (sha1=256): Excluded by user-provided restriction: version 10..") path)
       (fun () -> run ["update"; "local-app"; "--version=10.."]);
 
     let out = run ["update"; "local-app"; "--version=0.1.."] in

--- a/src/tests/test_solver.ml
+++ b/src/tests/test_solver.ml
@@ -473,13 +473,13 @@ let suite = "solver">::: [
     justify
       ("There is no possible selection using http://foo/Binary.xml 3.\n" ^
       "Can't find all required implementations:\n" ^
-      "- http://foo/Binary.xml#source -> 3 (impossible)\n" ^
+      "- http://foo/Binary.xml#source -> v3 (impossible)\n" ^
       "- http://foo/Compiler.xml -> (problem)\n" ^
       "    http://foo/Binary.xml#source 3 requires version ..!1.0, version 1.0..\n" ^
       "    Rejected candidates:\n" ^
-      "      sha1=999 (5): Incompatible with restriction: version ..!1.0\n" ^
-      "      sha1=345 (1.0): Incompatible with restriction: version ..!1.0\n" ^
-      "      sha1=678 (0.1): Incompatible with restriction: version 1.0..")
+      "      v5 (sha1=999): Incompatible with restriction: version ..!1.0\n" ^
+      "      v1.0 (sha1=345): Incompatible with restriction: version ..!1.0\n" ^
+      "      v0.1 (sha1=678): Incompatible with restriction: version 1.0..")
       iface ~source:true (`Remote_feed "http://foo/Source.xml") "impossible";
     justify
       ("http://foo/Compiler.xml 5 is selectable, but using it would produce a less optimal solution overall.\n\n" ^

--- a/src/zeroinstall/solver.ml
+++ b/src/zeroinstall/solver.ml
@@ -64,6 +64,13 @@ module Input = struct
   let pp_command f command = Element.pp f command.Impl.command_qdom
   let describe_problem = Impl_provider.describe_problem
 
+  let pp_version f impl = Version.pp f impl.Impl.parsed_version
+
+  let pp_impl_long f impl =
+    let id = id_of_impl impl in
+    let id = if String.length id > 20 then String.sub id 0 17 ^ "..." else id in
+    Format.fprintf f "v%a (%s)" pp_version impl id
+
   let compare_version a b = compare a.Impl.parsed_version b.Impl.parsed_version
 
   let dummy_impl =
@@ -144,8 +151,6 @@ module Input = struct
 
   let user_restrictions role =
     XString.Map.find_opt role.iface role.scope#extra_restrictions
-
-  let format_version impl = Version.to_string impl.Impl.parsed_version
 
   type conflict_class = private string
   let conflict_class _ = []


### PR DESCRIPTION
If a restriction didn't remove any candidates (either because it matched all of them or because another restriction already removed them) then don't bother reporting it.

Also, don't bother reporting a restriction that only removed candidates worse than the selected one (if any).

For user-provided restrictions, filter the rejects to show only the version(s) the user asked for (unless that would remove all of them). Since we only show the first 5 rejects, this would often mean that the
interesting candidates weren't even shown.

Also, improve the printing of impls. Allow the library user to specify the formatting, and change the default from `sha256=... (1)` to `v1 (sha256=...`) and truncate the hash.

Example output for  `0install select 0compile -c --version-for http://0install.net/2007/interfaces/ZeroInstall.xml 2.3.5 --version 1.7`:

Before:

```
Can't find all required implementations:
- http://0install.net/2006/interfaces/0compile.xml -> 1.7 (sha1new=091f01b62fc034d0741ca2daaadb1e951800f197)
    User requested version 1.7
- http://0install.net/2006/interfaces/0publish -> 0.26-post (.)
- http://0install.net/2007/interfaces/ZeroInstall.xml -> (problem)
    User requested version 2.3.5
    http://0install.net/2006/interfaces/0compile.xml 1.7 requires version 2.3.7..
    http://0install.net/2006/interfaces/0compile.xml 1.7 requires '0install' command
    Rejected candidates:
      . (2.3.12-post): Excluded by user-provided restriction: version 2.3.5
      sha1new=b4f7268bbca685f6f32ca71f018c03e822cc9e56 (2.3.12): Excluded by user-provided restriction: version 2.3.5
      sha1new=38db1113baf7ef5a352d406a51231687844098b2 (2.3.11): Excluded by user-provided restriction: version 2.3.5
      sha1new=31091e7ac1dde3fbfaeecae391db0ba7dbadd507 (2.3.10): Excluded by user-provided restriction: version 2.3.5
      sha1new=efcc544e8051c517ed790dddafd358a4f4bbe915 (2.3.9): Excluded by user-provided restriction: version 2.3.5
      ...
- https://apps.0install.net/python/python.xml -> 3.7.3-1 (package:deb:python3:3.7.3-1:x86_64)
    http://0install.net/2006/interfaces/0compile.xml 1.7 requires version 3..
    http://0install.net/2006/interfaces/0compile.xml 1.7 requires 'run' command
    http://0install.net/2006/interfaces/0publish 0.26-post requires version 3..
- https://apps.0install.net/utils/gnupg.xml -> 2.2.12-1-10.1 (package:deb:gnupg:2.2.12-1-10.1:*)
```

After:

```
Can't find all required implementations:                                      
- http://0install.net/2006/interfaces/0compile.xml -> v1.7 (sha1new=091f01b62...)
    User requested version 1.7
- http://0install.net/2006/interfaces/0publish -> v0.26-post (.)
- http://0install.net/2007/interfaces/ZeroInstall.xml -> (problem)
    User requested version 2.3.5
    http://0install.net/2006/interfaces/0compile.xml 1.7 requires version 2.3.7..
    Rejected candidates:
      v2.3.5 (sha1new=6f4892dfc...): Incompatible with restriction: version 2.3.7..
- https://apps.0install.net/python/python.xml -> v3.7.3-1 (package:deb:pytho...)
- https://apps.0install.net/utils/gnupg.xml -> v2.2.12-1-10.1 (package:deb:gnupg...)
```