### PR TITLE
Improve SIGPIPE handling

### DIFF
--- a/install.sh.src
+++ b/install.sh.src
@@ -4,7 +4,7 @@ set -eu
 cd `dirname $0`/files
 
 echo Testing binary...
-./0install --version | head -1
+./0install --version
 echo OK
 echo
 

--- a/src/cli/main.ml
+++ b/src/cli/main.ml
@@ -9,6 +9,15 @@ open Support
 open Support.Common
 module U = Support.Utils
 
+(* There's no reason to use SIGPIPE in a language with exceptions. This
+   means that the function with the problem will raise an exception, instead
+   of terminating the whole program. *)
+let () =
+  match Sys.os_type with
+  | "Unix" | "Cygwin" ->
+    let _ : Sys.signal_behavior = Sys.(signal sigpipe Signal_ignore) in ()
+  | _ -> ()
+
 let crash_handler system crash_dir entries =
   U.makedirs system crash_dir 0o700;
   let leaf =


### PR DESCRIPTION
- Avoid possible SIGPIPE in `install.sh`.
  If we're very unlucky then `./0install --version | head -1` can fail because 0install may do the write in two parts and head may close the pipe between them.

- Handle SIGPIPE using exceptions.
  There are some CI cases where the unit-tests failed with `test alias src/tests/runtest (got signal PIPE)`. Make sure that we handle these errors using exceptions, not signals. At least, this should show where they're coming from.