### PR TITLE
Handle implementations that directly conflict with themselves

### DIFF
--- a/src/solver/sat.ml
+++ b/src/solver/sat.ml
@@ -599,7 +599,9 @@ module Make(User : USER) =
       (*	return True	# Trivially true *)
 
       (* Ensure no duplicates *)
-      assert (List.length (remove_duplicates lits) = List.length lits);
+      if List.length (remove_duplicates lits) <> List.length lits then (
+        invalid_arg (Format.asprintf "at_most_one(%a): duplicates in list!" pp_lits lits)
+      );
 
       (* Ignore any literals already known to be False.
          If any are True then they're enqueued and we'll process them

--- a/src/solver/sat.mli
+++ b/src/solver/sat.mli
@@ -38,8 +38,6 @@ module Make (User : USER) : sig
       during setup vs problems discovered by the solver. *)
   val impossible : t -> unit -> unit
 
-  type added_result = AddedFact of bool | AddedClause of clause
-
   (** Add a clause requiring at least one literal to be [True]. e.g. [A or B or not(C)].
       [reason] is used in debug messages. *)
   val at_least_one : t -> ?reason:string -> lit list -> unit
@@ -51,7 +49,8 @@ module Make (User : USER) : sig
 
   type at_most_one_clause
 
-  (** Add a clause preventing more than one literal in the list from being [True]. *)
+  (** Add a clause preventing more than one literal in the list from being [True].
+      @raise Invalid_argument if the list contains duplicates. *)
   val at_most_one : t -> lit list -> at_most_one_clause
 
   (** [run_solver decider] tries to solve the SAT problem. It simplifies it as much as possible first. When it

--- a/src/solver/solver_core.ml
+++ b/src/solver/solver_core.ml
@@ -373,7 +373,10 @@ module Make (Model : S.SOLVER_INPUT) = struct
       (* If [user_var] is selected, don't select an incompatible version of the optional dependency.
          We don't need to do this explicitly in the [essential] case, because we must select a good
          version and we can't select two. *)
-      S.at_most_one sat (user_var :: fail) |> ignore;
+      try
+        S.at_most_one sat (user_var :: fail) |> ignore;
+      with Invalid_argument reason ->   (* Explicitly conflicts with itself! *)
+        S.at_least_one sat [S.neg user_var] ~reason
     )
 
   (* Add the implementations of an interface to the ImplCache (called the first time we visit it). *)

--- a/src/tests/data/solves.xml
+++ b/src/tests/data/solves.xml
@@ -1708,4 +1708,24 @@ Can't find all required implementations:
     </problem>
   </test>
 
+  <test name='self-conflict'>
+    <interface local-path='foo.xml'>
+      <name>Foo</name>
+      <summary>Conflicts with itself!</summary>
+      <group>
+	<restricts interface='./foo.xml' version='0'/>
+	<implementation id='1' local-path='.' version='1'/>
+      </group>
+    </interface>
+
+    <requirements fails='true' interface='./foo.xml'/>
+
+    <problem>
+Can't find all required implementations:
+- /root/foo.xml -> (problem)
+    Rejected candidates:
+      v1 (1): Requires /root/foo.xml version 0
+    </problem>
+  </test>
+
 </test-cases>


### PR DESCRIPTION
When an implementation has an optional dependency or a restriction on another interface then we add a clause to ensure that we don't select both it and the conflicting implementation(s), e.g.

    at_most_one [impl; conflict_impl]

However, if `impl` conflicts with itself then we get:

    at_most_one [impl; impl]

This triggered an assertion failure:

    Assert_failure duniverse/0install/src/solver/sat.ml:602:6

Now we report e.g.

    - /root/foo.xml -> (problem)
        Rejected candidates:
          v1 (1): Requires /root/foo.xml version 0

Fixes #179.