### PR TITLE
Add + to list of allowed characters in "extract"

### DIFF
--- a/src/zeroinstall/archive.ml
+++ b/src/zeroinstall/archive.ml
@@ -129,7 +129,7 @@ let extract_tar config ~dstdir ?extract ~compression archive =
 
   extract |> if_some (fun extract ->
     (* Limit the characters we accept, to avoid sending dodgy strings to tar *)
-    if not (Str.string_match (Str.regexp "^[a-zA-Z0-9][- _a-zA-Z0-9.]*$") extract 0) then
+    if not (Str.string_match (Str.regexp "^[a-zA-Z0-9][-+ _a-zA-Z0-9.]*$") extract 0) then
       Safe_exn.failf "Illegal character in extract attribute ('%s')" extract
   );
 


### PR DESCRIPTION
The archive https://download.blender.org/release/Blender2.83/blender-2.83.15-linux-x64.tar.xz has a top-level directory named
`blender-2.83.15-stable+blender-v283-release.fd3036520101-linux.x86_64-release`. 0install currently rejects this with the message "Illegal character in extract attribute".

This PR fixes this by adding `+` to the list of allowed characters in `extract`. I don't think this could be used to make `tar` do anything unexpected.

As a temporary workaround I will use `extract=""` and `main="blender-2.83.15-stable+blender-v283-release.fd3036520101-linux.x86_64-release/blender"`.