### PR TITLE
Replace uses of deprecated Stdlib.Stream and Lwt_unix.yield

### DIFF
--- a/src/gui_gtk/icon_cache.ml
+++ b/src/gui_gtk/icon_cache.ml
@@ -54,7 +54,7 @@ let create config ~fetcher =
                 (* If the icon is now in the disk cache, load it into the memory cache and trigger a refresh.
                    If not, we'll be left with None in the cache so we don't try again. *)
                 let icon_path = Zeroinstall.Feed_cache.get_cached_icon_path config master_feed in
-                Lwt_unix.yield () >|= fun () -> (* Make sure we're not already inside update() *)
+                Lwt.pause () >|= fun () -> (* Make sure we're not already inside update() *)
                 icon_path |> if_some (fun path ->
                     load_icon path |> if_some (fun _ -> update ())
                   )

--- a/src/support/stream.ml
+++ b/src/support/stream.ml
@@ -1,0 +1,61 @@
+module LList = struct
+  type 'a item = Nil | Cons of 'a * 'a t
+  and 'a t = 'a item Lazy.t
+
+  let rec of_list = function
+    | [] -> lazy Nil
+    | x :: xs -> lazy (Cons (x, of_list xs))
+
+  let rec from fn =
+    lazy (
+      match fn () with
+      | None -> Nil
+      | Some x -> Cons (x, from fn)
+    )
+end
+
+type 'a t = {
+  mutable next : 'a LList.t;
+  mutable count : int;
+}
+
+exception Failure
+
+let of_lazy x = { next = x; count = 0 }
+
+let of_list x = of_lazy (LList.of_list x)
+
+let count t = t.count
+
+let empty t =
+  match t.next with
+  | lazy Nil -> ()
+  | _ -> raise Failure
+
+let from fn = of_lazy (LList.from fn)
+
+let next t =
+  match Lazy.force t.next with
+  | Nil -> raise Failure
+  | Cons (x, next) ->
+    t.next <- next;
+    t.count <- t.count + 1;
+    x
+
+let junk t = ignore (next t)
+
+let npeek n t =
+  let rec aux (next : _ LList.t) = function
+    | 0 -> []
+    | i ->
+      match Lazy.force next with
+      | Nil -> []
+      | Cons (x, next) ->
+        x :: aux next (i - 1)
+  in
+  aux t.next n
+
+let peek t =
+  match Lazy.force t.next with
+  | Nil -> None
+  | Cons (x, _) -> Some x

--- a/src/support/stream.mli
+++ b/src/support/stream.mli
@@ -1,0 +1,15 @@
+(** This is a reimplementation of parts of the OCaml 4 Stream API, which was deprecated in 4.14.
+    The only API difference is that {!from}'s callback no longer takes a position argument. *)
+
+type 'a t
+
+exception Failure
+
+val of_list : 'a list -> 'a t
+val count : 'a t -> int
+val empty : 'a t -> unit
+val from : (unit -> 'a option) -> 'a t
+val next : 'a t -> 'a
+val junk : 'a t -> unit
+val npeek : int -> 'a t -> 'a list
+val peek : 'a t -> 'a option

--- a/src/tests/pk_service.ml
+++ b/src/tests/pk_service.ml
@@ -61,11 +61,11 @@ let start version : (unit -> unit) Lwt.t =
               D.OBus_signal.emit s_Package1 obj ("installing", "gnupg;2.0.22;x86_64;arch", "summary")
           end >>= fun () ->
           set_percentage (Int32.of_int 1);
-          Lwt_main.yield () >>= fun () ->
+          Lwt.pause () >>= fun () ->
           set_percentage (Int32.of_int 50);
-          Lwt_main.yield () >>= fun () ->
+          Lwt.pause () >>= fun () ->
           set_percentage (Int32.of_int 100);
-          Lwt_main.yield () >>= fun () ->
+          Lwt.pause () >>= fun () ->
           if version >= [| 0; 8; 1 |] then (
             D.OBus_signal.emit s_Package2 obj (Int32.of_int 18, "gnupg;2.0.22;x86_64;arch", "summary") >>= fun () ->
             D.OBus_signal.emit s_Finished2 obj (Int32.of_int 1, Int32.of_int 5)

--- a/src/zeroinstall/packagekit.ml
+++ b/src/zeroinstall/packagekit.ml
@@ -315,7 +315,7 @@ let make lang_spec =
                 );
 
               (* Yield briefly, so that other packages can be added to the final batch. *)
-              Lwt_main.yield () >>= fun () ->
+              Lwt.pause () >>= fun () ->
               (* (note: next_batch might also have become empty, if someone else added our items to their batch) *)
               do_batch ();
 

--- a/src/zeroinstall/version.ml
+++ b/src/zeroinstall/version.ml
@@ -124,6 +124,27 @@ let parse_expr s =
  * We use a special-looking decimal number to make it more obvious what has happened. *)
 let version_limit = 9999999999999999L
 
+module Stream = struct
+  type t = { x : string; mutable pos : int }
+
+  let of_string x = { x; pos = 0 }
+
+  let junk_n t n =
+    let i' = t.pos + n in
+    assert (n >= 0 && i' <= String.length t.x);
+    t.pos <- i'
+
+  let junk t = junk_n t 1
+
+  let peek t =
+    if t.pos < String.length t.x then Some (t.x.[t.pos])
+    else None
+
+  let npeek n t =
+    let n = min n (String.length t.x - t.pos) in
+    List.init n (fun i -> t.x.[t.pos + i])
+end
+
 let try_cleanup_distro_version version =
   let result' = ref [] in
   let stream = Stream.of_string version in


### PR DESCRIPTION
Avoids compiler warnings on OCaml 4.14 (and failure on OCaml 5.00).