### PR TITLE
Make compatible with Yojson `json` type deprecation

### DIFF
--- a/0install.opam
+++ b/0install.opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "0install-solver"
-  "yojson"
+  "yojson" {>= "1.7.0"}
   "xmlm"
   "ounit2" {with-test}
   "lwt"

--- a/src/support/json.ml
+++ b/src/support/json.ml
@@ -1,3 +1,0 @@
-[@@@ocaml.warning "-3"]
-
-type t = Yojson.Basic.json

--- a/src/zeroinstall/exec.ml
+++ b/src/zeroinstall/exec.ml
@@ -29,7 +29,7 @@ class launcher_builder config script =
 
     method setenv name command_argv env =
       let open Yojson.Basic in
-      let json : Json.t = `List (List.map (fun a -> `String a) command_argv) in
+      let json : Yojson.Basic.t = `List (List.map (fun a -> `String a) command_argv) in
       let envname = "zeroinstall_runenv_" ^ name in
       let value = to_string json in
       log_info "%s=%s" envname value;

--- a/src/zeroinstall/json_connection.mli
+++ b/src/zeroinstall/json_connection.mli
@@ -19,8 +19,8 @@ open Support
 
 type t
 
-type opt_xml = [Json.t | `WithXML of Json.t * Qdom.element ]
-type 'a handler = (string * Json.t list) -> [opt_xml | `Bad_request] Lwt.t
+type opt_xml = [Yojson.Basic.t | `WithXML of Yojson.Basic.t * Qdom.element ]
+type 'a handler = (string * Yojson.Basic.t list) -> [opt_xml | `Bad_request] Lwt.t
 
 val client :
   from_peer:Lwt_io.input_channel ->
@@ -40,7 +40,7 @@ val server :
   t * unit Lwt.t
 (** Like [client], except that the server starts by sending the version number rather than reading it. *)
 
-val invoke : t -> ?xml:Qdom.element -> string -> Json.t list -> opt_xml Lwt.t
-val notify : t -> ?xml:Qdom.element -> string -> Json.t list -> unit Lwt.t
+val invoke : t -> ?xml:Qdom.element -> string -> Yojson.Basic.t list -> opt_xml Lwt.t
+val notify : t -> ?xml:Qdom.element -> string -> Yojson.Basic.t list -> unit Lwt.t
 
 val pp_opt_xml : Format.formatter -> opt_xml -> unit

--- a/src/zeroinstall/requirements.mli
+++ b/src/zeroinstall/requirements.mli
@@ -20,5 +20,5 @@ type t = {
 val run : Sigs.iface_uri -> t
 (** [run iface] is a requirement to run [iface] with no restrictions. *)
 
-val of_json : Json.t -> t
-val to_json : t -> Json.t
+val of_json : Yojson.Basic.t -> t
+val to_json : t -> Yojson.Basic.t


### PR DESCRIPTION
Yojson 2.0 removes the `json` type, so this code switches to using `t`.