### PR TITLE
Fix plugin loading on bytecode-only systems

### DIFF
--- a/src/gui_gtk/dune
+++ b/src/gui_gtk/dune
@@ -7,4 +7,4 @@
 (install
   (section lib)
   (package 0install-gtk)
-  (files gui_gtk%{ext_plugin}))
+  (files gui_gtk.cmxs))

--- a/src/zeroinstall/gui.ml
+++ b/src/zeroinstall/gui.ml
@@ -324,7 +324,7 @@ let try_get_gui config ~use_gui =
           let bindir = Filename.dirname (U.realpath system config.abspath_0install) in
 
           let check_plugin_dir plugin_dir =
-            let plugin_path = plugin_dir +/ "gui_gtk.cma" |> Dynlink.adapt_filename in
+            let plugin_path = plugin_dir +/ "gui_gtk.cmxs" in
             log_info "Checking for GTK plugin at '%s'" plugin_path;
             if system#file_exists plugin_path then Some plugin_path else None in
 


### PR DESCRIPTION
It seems that dune always builds the plugin as `gui_gtk.cmxs`, even when it's actually bytecode.

Not sure if this will actually let the GUI run, but at least it fixes the build and it will run without the GUI OK.