### PR TITLE
Automate release of Python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: CI - Python version
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Prepare
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: '5.12.x'
+      - uses: gittools/actions/gitversion/execute@v0.10.2
+        id: gitversion
+
+      # Build
+      - name: Inject version number
+        run: |
+          sed -i "s/^version = '.*'$/version = '${{steps.gitversion.outputs.legacySemVer}}'/" zeroinstall/__init__.py
+          sed -i "s/^version = '.*'$/version = '${{steps.gitversion.outputs.legacySemVer}}'/" zeroinstall/0launch-gui/gui.py
+      - name: make translations
+        run: |
+          sudo apt-get -qq install gettext
+          make translations
+      - name: 0template
+        run: ./0install.sh run https://apps.0install.net/0install/0template.xml 0install-python.xml.template version=${{steps.gitversion.outputs.legacySemVer}}
+      - name: 0test
+        run: ./0install.sh run https://apps.0install.net/0install/0test.xml 0install-python-${{steps.gitversion.outputs.legacySemVer}}.xml
+
+      # Release
+      - name: Create GitHub Release
+        if: steps.gitversion.outputs.preReleaseLabel == ''
+        uses: softprops/action-gh-release@v1
+        with:
+          files: 0install-${{steps.gitversion.outputs.legacySemVer}}.*
+      - name: Publish feed
+        if: steps.gitversion.outputs.preReleaseLabel == ''
+        env:
+          GH_TOKEN: ${{secrets.PERSONAL_TOKEN}}
+        run: >
+          gh workflow run --repo=0install/apps Incoming
+          -f feed_url=https://github.com/${{github.repository}}/releases/download/${{steps.gitversion.outputs.legacySemVer}}/0install-${{steps.gitversion.outputs.legacySemVer}}.xml
+          -f archive_url=https://github.com/${{github.repository}}/releases/download/${{steps.gitversion.outputs.legacySemVer}}/0install-${{steps.gitversion.outputs.legacySemVer}}.tar.bz2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ share/locale/zero-install.pot
 /tests/TEST*.xml
 /tests/coverage.xml
 /ocaml/_build
+/0install-python-*.xml
+/0install-python-*.tar.bz2

--- a/0install-python.xml
+++ b/0install-python.xml
@@ -12,13 +12,6 @@
   <feed-for interface="https://apps.0install.net/0install/0install-python.xml"/>
   <category>System</category>
 
-  <release:management xmlns:release="http://zero-install.sourceforge.net/2007/namespaces/0release">
-    <!-- Update the copy of the version number -->
-    <release:action phase="commit-release">sed -i &quot;s/^version = '.*'$/version = '$RELEASE_VERSION'/&quot; zeroinstall/__init__.py</release:action>
-    <release:action phase="commit-release">sed -i &quot;s/^version = '.*'$/version = '$RELEASE_VERSION'/&quot; zeroinstall/0launch-gui/gui.py</release:action>
-    <release:action phase="generate-archive">rm .gitignore; make translations</release:action>
-  </release:management>
-
   <group license="OSI Approved :: GNU Lesser General Public License (LGPL)" main="0launch">
     <command name="run" path="0launch">
       <runner interface="https://apps.0install.net/python/python.xml"/>
@@ -44,6 +37,7 @@
       <environment insert="runenv.cli.template" mode="replace" name="ZEROINSTALL_CLI_TEMPLATE"/>
     </requires>
 
-    <implementation id="." version="2.3.16-post"/>
+    <!-- Use very high version number to treat local build as newer than any public version. -->
+    <implementation id="local" version="100-pre" stability="developer" local-path="."/>
   </group>
 </interface>

--- a/0install-python.xml.template
+++ b/0install-python.xml.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Zero Install - Python version</name>
+  <summary>Python version of 0install, the decentralized installation system</summary>
+  <description>This is the Python version of Zero Install. Zero Install is a cross-platform, decentralized installation system. Instead of having a central repository in which all software is placed under a naming scheme managed by some central authority, programs and libraries in Zero Install are identified by URIs. Anyone who can create a web-page can publish software. Anyone can install software (not just administrators).</description>
+
+  <homepage>http://0install.net/</homepage>
+
+  <icon href="http://0install.net/feed_icons/ZeroInstall.png" type="image/png"/>
+
+  <feed-for interface="https://apps.0install.net/0install/0install-python.xml"/>
+  <category>System</category>
+
+  <group license="OSI Approved :: GNU Lesser General Public License (LGPL)" main="0launch">
+    <command name="run" path="0launch">
+      <runner interface="https://apps.0install.net/python/python.xml"/>
+    </command>
+    <command name="0install" path="0install">
+      <runner interface="https://apps.0install.net/python/python.xml"/>
+    </command>
+    <command name="test" path="tests/testall.py">
+      <runner interface="https://apps.0install.net/python/python.xml">
+        <arg>-tt</arg>
+      </runner>
+    </command>
+
+    <requires interface="https://apps.0install.net/utils/gnupg.xml">
+      <executable-in-var name="ZEROINSTALL_GPG"/>
+    </requires>
+
+    <requires interface="https://apps.0install.net/python/python.xml" version="3.4.."/>
+    <requires interface="https://apps.0install.net/python/python.xml" os="Windows" version="3.4..!3.8"/>
+    <requires interface="https://apps.0install.net/python/pywin32.xml" os="Windows"/>
+
+    <requires interface="http://0install.net/2012/interfaces/0install-runenv-cli.xml" os="Windows" version="2.0.2..">
+      <environment insert="runenv.cli.template" mode="replace" name="ZEROINSTALL_CLI_TEMPLATE"/>
+    </requires>
+
+    <implementation version="{version}" local-path=".">
+      <manifest-digest/>
+      <archive href="0install-python-{version}.tar.bz2"/>
+    </implementation>
+  </group>
+</interface>

--- a/0install.sh
+++ b/0install.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+if [ "$#" -eq 0 ]; then
+    echo "This script runs 0install from your PATH or downloads it on-demand."
+    echo ""
+    echo "To run 0install commands without adding 0install to your PATH:"
+    echo "./0install.sh --help"
+    echo "./0install.sh COMMAND [OPTIONS]"
+    echo ""
+    echo "To install to /usr/local:"
+    echo "sudo ./0install.sh install local"
+    echo ""
+    echo "To install to your home directory:"
+    echo "./0install.sh install home"
+    exit 1
+fi
+
+download() {
+    zeroinstall_release=0install-$(uname | tr '[:upper:]' '[:lower:]')-$(uname -m)-${ZEROINSTALL_VERSION:-latest}
+    download_dir=~/.cache/0install.net/$zeroinstall_release
+
+    if [ ! -f $download_dir/files/0install ]; then
+        echo "Downloading 0install..." >&2
+        rm -rf $download_dir
+        mkdir -p $download_dir
+        curl -sSL https://get.0install.net/$zeroinstall_release.tar.bz2 | tar xj --strip-components 1 --directory $download_dir
+    fi
+}
+
+if [ "$1" = "install" ]; then
+    download
+    shift 1
+    $download_dir/install.sh "$@"
+else
+    if command -v 0install > /dev/null 2> /dev/null; then
+        0install "$@"
+    else
+        download
+        $download_dir/files/0install "$@"
+    fi
+fi

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,24 @@
+mode: ContinuousDeployment
+
+# Generate 0install-compatible version numbers
+branches:
+  # Mainline branch
+  main:
+    regex: ^b2\.3$
+    tag: pre
+
+  # Stabilization branches
+  release:
+    tag: rc
+  hotfix:
+    tag: rc
+
+  # Topic branches
+  feature:
+    tag: pre-pre
+  pull-request:
+    tag: pre-pre
+  fallback:
+    source-branches: [main]
+    regex: ^(?!b2\.3|feature|pull|pr)
+    tag: pre-pre

--- a/zeroinstall/0launch-gui/gui.py
+++ b/zeroinstall/0launch-gui/gui.py
@@ -8,7 +8,7 @@ from zeroinstall.injector import handler, download
 gobject = tasks.get_loop().gobject
 glib = tasks.get_loop().glib
 
-version = '2.3.16'
+version = 'git-checkout'
 
 class GUIHandler(handler.Handler):
 	dl_callbacks = None		# Download -> [ callback ]

--- a/zeroinstall/__init__.py
+++ b/zeroinstall/__init__.py
@@ -13,7 +13,7 @@ The Python implementation of the Zero Install injector is divided into five sub-
 @var _: a function for translating strings using the zero-install domain (for use internally by Zero Install)
 """
 
-version = '2.3.16'
+version = 'git-checkout'
 
 import logging
 


### PR DESCRIPTION
- Rename `ZeroInstall.xml` to `0install-python.xml`
- Add CI with GitHub Actions
- Replace `0release` with `0template`
- Automatically publish release on Git tag

When a new Git tag is pushed to the repository, the GitHub pipeline will do the following:
1. Determine the version number from Git tag and `sed` it into the code
2. Run `make translations` and `0test`
3. Run `0template` to generate `0install-python-1.2.3.xml` and `0install-python-1.2.3.tar.gz`
4. Create a GitHub Release with `0install-python-1.2.3.xml` and `0install-python-1.2.3.tar.gz` as artifacts
5. Trigger another GitHub pipeline in the [0install/apps](https://github.com/0install/apps) repo, passing the URLs of  `0install-python-1.2.3.xml` and `0install-python-1.2.3.tar.gz` as inputs
   - This pipeline adds `0install-python-1.2.3.tar.gz` to `archives.db` and `0install-python-1.2.3.xml` to `0install-python.xml`